### PR TITLE
Ensure dashboard metrics initialization

### DIFF
--- a/core/altcoin_derive.py
+++ b/core/altcoin_derive.py
@@ -454,7 +454,11 @@ from core.dashboard import init_shared_metrics
 
 
 def convert_txt_to_csv_loop(shared_shutdown_event, shared_metrics=None):
-    init_shared_metrics(shared_metrics)
+    try:
+        init_shared_metrics(shared_metrics)
+        print("[debug] Shared metrics initialized for", __name__)
+    except Exception as e:
+        print(f"[error] init_shared_metrics failed in {__name__}: {e}")
     """
     Monitors VANITY_OUTPUT_DIR for .txt files and converts them to CSV using GPU derivation.
     Handles multiple files in parallel using ThreadPoolExecutor.

--- a/core/csv_checker.py
+++ b/core/csv_checker.py
@@ -152,7 +152,11 @@ def check_csv_against_addresses(csv_file, address_set, recheck=False):
 
 
 def check_csvs_day_one(shared_metrics=None):
-    init_shared_metrics(shared_metrics)
+    try:
+        init_shared_metrics(shared_metrics)
+        print("[debug] Shared metrics initialized for", __name__)
+    except Exception as e:
+        print(f"[error] init_shared_metrics failed in {__name__}: {e}")
     address_sets = {}
     for coin, columns in coin_columns.items():
         full_path = os.path.join(FULL_DIR, f"{coin}_funded.txt")
@@ -171,7 +175,11 @@ def check_csvs_day_one(shared_metrics=None):
     update_csv_eta()
 
 def check_csvs(shared_metrics=None):
-    init_shared_metrics(shared_metrics)
+    try:
+        init_shared_metrics(shared_metrics)
+        print("[debug] Shared metrics initialized for", __name__)
+    except Exception as e:
+        print(f"[error] init_shared_metrics failed in {__name__}: {e}")
     address_sets = {}
     for coin, columns in coin_columns.items():
         unique_path = os.path.join(UNIQUE_DIR, f"{coin}_UNIQUE.txt")

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -146,7 +146,11 @@ from core.dashboard import init_shared_metrics
 
 
 def start_keygen_loop(shared_metrics=None):
-    init_shared_metrics(shared_metrics)
+    try:
+        init_shared_metrics(shared_metrics)
+        print("[debug] Shared metrics initialized for", __name__)
+    except Exception as e:
+        print(f"[error] init_shared_metrics failed in {__name__}: {e}")
     if not os.path.exists(VANITY_OUTPUT_DIR):
         os.makedirs(VANITY_OUTPUT_DIR)
 

--- a/main.py
+++ b/main.py
@@ -63,7 +63,11 @@ from core.dashboard import init_shared_metrics
 
 
 def metrics_updater(shared_metrics=None):
-    init_shared_metrics(shared_metrics)
+    try:
+        init_shared_metrics(shared_metrics)
+        print("[debug] Shared metrics initialized for", __name__)
+    except Exception as e:
+        print(f"[error] init_shared_metrics failed in {__name__}: {e}")
     while True:
         try:
             from core.keygen import keygen_progress
@@ -102,7 +106,11 @@ def run_all_processes(args, shutdown_event, shared_metrics):
     from core.backlog import start_backlog_conversion_loop  # Optional non-GPU parser
     from core.dashboard import init_shared_metrics
 
-    init_shared_metrics(shared_metrics)
+    try:
+        init_shared_metrics(shared_metrics)
+        print("[debug] Shared metrics initialized for", __name__)
+    except Exception as e:
+        print(f"[error] init_shared_metrics failed in {__name__}: {e}")
     processes = []
 
     if ENABLE_CHECKPOINT_RESTORE:
@@ -169,7 +177,11 @@ def run_allinkeys(args):
     manager = multiprocessing.Manager()
     shared_metrics = manager.dict({k: (manager.dict(v) if isinstance(v, dict) else v)
                                    for k, v in _default_metrics().items()})
-    init_shared_metrics(shared_metrics)
+    try:
+        init_shared_metrics(shared_metrics)
+        print("[debug] Shared metrics initialized for", __name__)
+    except Exception as e:
+        print(f"[error] init_shared_metrics failed in {__name__}: {e}")
 
     if args.match_test:
         test_data = {


### PR DESCRIPTION
## Summary
- initialize shared metrics at the start of worker processes
- add debug output and error handling for initialization failures

## Testing
- `pytest -q`
- `python -m py_compile core/altcoin_derive.py core/csv_checker.py core/keygen.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6865cbe690b483278b6a96c28c387cc6