### PR TITLE
Fix missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pgpy
 pynvml
 openpyxl
 tk
+ttkbootstrap
 tqdm
 pyttsx3
 pyaudio


### PR DESCRIPTION
## Summary
- add `ttkbootstrap` to requirements since `dashboard_gui.py` imports it

## Testing
- `pip install -r requirements.txt` *(fails: Getting requirements to build wheel)*

------
https://chatgpt.com/codex/tasks/task_e_6865ed1bff088327a06c923b7d758fec