### PR TITLE
Improve alert tests & dashboard info

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -401,6 +401,7 @@ STATS_TO_DISPLAY = {
     "addresses_checked_today": SHOW_ADDRESS_CHECKED_COUNTS_TODAY,
     "addresses_checked_lifetime": SHOW_ADDRESS_CHECKED_COUNTS_LIFETIME,
     "gpu_stats": True,
+    "last_updated": True,
 }
 # ===================== ⏱️ DASHBOARD REFRESH ==========================
 DASHBOARD_REFRESH_INTERVAL = 1.0  # seconds between dashboard UI updates
@@ -429,6 +430,7 @@ METRICS_LABEL_MAP = {
     "addresses_checked_today": "Addresses Checked Today",
     "addresses_checked_lifetime": "Addresses Checked Lifetime",
     "gpu_stats": "GPU Stats",
+    "last_updated": "Last Updated",
 }
 # ===================== ⚠️ ALERT CONFIG OPTIONS FOR GUI ======================
 ALERT_OPTIONS = {

--- a/core/alerts.py
+++ b/core/alerts.py
@@ -214,8 +214,11 @@ def run_test_alerts_from_csv(csv_path=None):
         csv_path = os.path.join(DOWNLOADS_DIR, "test_alerts.csv")
 
     if not os.path.exists(csv_path):
-        log_message("⚠️ test_alerts.csv not found. Run downloader first.", "WARN")
-        return
+        from core.downloader import generate_test_csv
+        csv_path = generate_test_csv()
+        if not csv_path or not os.path.exists(csv_path):
+            log_message("⚠️ test_alerts.csv not found and could not be generated.", "WARN")
+            return
 
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)

--- a/core/dashboard.py
+++ b/core/dashboard.py
@@ -113,6 +113,7 @@ def _default_metrics():
         },
         "pin_reset_required": False,
         "metrics_last_reset": datetime.now().isoformat(),
+        "last_updated": datetime.now().isoformat(),
         "thread_health_flags": THREAD_HEALTH.copy()
     }
 

--- a/main.py
+++ b/main.py
@@ -147,6 +147,7 @@ def metrics_updater(shared_metrics=None):
             prog = keygen_progress()
             stats['keys_generated_lifetime'] = prog['total_keys_generated']
             stats['uptime'] = prog['elapsed_time']
+            stats['last_updated'] = datetime.utcnow().strftime('%H:%M:%S')
             try:
                 from config.settings import BATCH_SIZE
                 stats['vanity_progress_percent'] = round(
@@ -270,6 +271,9 @@ def run_allinkeys(args):
     display_logo()
 
     assign_gpu_roles()
+    test_csv = os.path.join(DOWNLOAD_DIR, "test_alerts.csv")
+    if not os.path.exists(test_csv):
+        generate_test_csv()
     shutdown_event = multiprocessing.Event()
 
     # Use dashboard's helper to create a Manager-backed shared metrics dict with

--- a/ui/dashboard_gui.py
+++ b/ui/dashboard_gui.py
@@ -242,6 +242,7 @@ class DashboardGUI:
     def test_alerts(self):
         from core.alerts import run_test_alerts_from_csv
         run_test_alerts_from_csv()
+        messagebox.showinfo("Test Alerts", "Test alerts dispatched. Check logs for details.")
 
     def reset_metrics_prompt(self):
         resp = messagebox.askyesno("Reset Metrics", "Include lifetime stats?")


### PR DESCRIPTION
## Summary
- regenerate `test_alerts.csv` if missing and show info when running Test Alerts
- add automatic creation of the test CSV on startup
- track dashboard refresh time via new `last_updated` metric

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6865f4d616e0832795c8eb8090b2f6d8