### PR TITLE
Prevented duplicate sys.stdout reassignment to fix I/O operation on closed file

### DIFF
--- a/core/altcoin_derive.py
+++ b/core/altcoin_derive.py
@@ -19,7 +19,6 @@ import time
 import threading
 import multiprocessing
 import io
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace', line_buffering=True)
 
 _gpu_logged_once = False
 

--- a/core/csv_checker.py
+++ b/core/csv_checker.py
@@ -18,8 +18,6 @@ from core.logger import log_message
 from utils.pgp_utils import encrypt_with_pgp
 from core.dashboard import update_dashboard_stat, increment_metric, init_shared_metrics
 
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace', line_buffering=True)
-
 MATCHED_CSV_DIR = os.path.join(CSV_DIR, "matched_csv")
 os.makedirs(MATCHED_CSV_DIR, exist_ok=True)
 # Track last 10 check times for rolling average

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -19,9 +19,8 @@ from config.settings import (
     MAX_OUTPUT_FILE_SIZE,
     MAX_OUTPUT_LINES,
     ROTATE_INTERVAL_SECONDS
-)
 
-sys.stdout.reconfigure(encoding='utf-8', line_buffering=True)  # ✅ Safe print emojis on Win terminal
+)
 
 from config.constants import SECP256K1_ORDER
 from core.checkpoint import load_keygen_checkpoint as load_checkpoint, save_keygen_checkpoint as save_checkpoint

--- a/core/logger.py
+++ b/core/logger.py
@@ -7,8 +7,7 @@ import sys
 import logging
 from config.settings import LOG_DIR, LOG_LEVEL, LOG_TO_CONSOLE, LOG_TO_FILE
 
-# ✅ Force stdout to UTF-8
-sys.stdout = open(sys.stdout.fileno(), mode='w', encoding='utf-8', buffering=1)
+# stdout is configured in main
 
 console_handler = logging.StreamHandler(sys.stdout)
 console_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))

--- a/main.py
+++ b/main.py
@@ -12,7 +12,14 @@ from datetime import datetime
 from multiprocessing import Process, set_start_method
 import psutil
 
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace')
+# Wrap stdout once with UTF-8 encoding if not already wrapped
+if not isinstance(sys.stdout, io.TextIOWrapper):
+    sys.stdout = io.TextIOWrapper(
+        sys.stdout.buffer,
+        encoding='utf-8',
+        errors='replace',
+        line_buffering=True
+    )
 
 try:
     import GPUtil


### PR DESCRIPTION
## Summary
- avoid reassigning stdout in `core` modules
- set utf-8 TextIOWrapper once in `main.py`
- remove logger stdout open now that main handles it

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6865fc6fe2408327984a9f0e8452f61a