### PR TITLE
Improve funded file lookup for test alerts

### DIFF
--- a/core/csv_checker.py
+++ b/core/csv_checker.py
@@ -12,6 +12,7 @@ from config.settings import (
     CSV_DIR, UNIQUE_DIR, FULL_DIR, CHECKED_CSV_LOG, RECHECKED_CSV_LOG,
     ENABLE_ALERTS, ENABLE_PGP, PGP_PUBLIC_KEY_PATH
 )
+from utils.file_utils import find_latest_funded_file
 from config.coin_definitions import coin_columns
 from core.alerts import alert_match
 from core.logger import log_message
@@ -161,9 +162,12 @@ def check_csvs_day_one(shared_metrics=None):
         print(f"[error] init_shared_metrics failed in {__name__}: {e}", flush=True)
     address_sets = {}
     for coin, columns in coin_columns.items():
-        full_path = os.path.join(FULL_DIR, f"{coin}_funded.txt")
-        if os.path.exists(full_path):
+        full_path = find_latest_funded_file(coin, FULL_DIR)
+        if full_path:
+            log_message(f"🔎 Using funded list {os.path.basename(full_path)} for {coin.upper()}.")
             address_sets[coin] = load_funded_addresses(full_path)
+        else:
+            log_message(f"⚠️ No funded list found for {coin.upper()} in FULL_DIR", "WARN")
 
     combined_set = set.union(*address_sets.values()) if address_sets else set()
 
@@ -184,9 +188,12 @@ def check_csvs(shared_metrics=None):
         print(f"[error] init_shared_metrics failed in {__name__}: {e}", flush=True)
     address_sets = {}
     for coin, columns in coin_columns.items():
-        unique_path = os.path.join(UNIQUE_DIR, f"{coin}_UNIQUE.txt")
-        if os.path.exists(unique_path):
+        unique_path = find_latest_funded_file(coin, UNIQUE_DIR)
+        if unique_path:
+            log_message(f"🔎 Using unique list {os.path.basename(unique_path)} for {coin.upper()}.")
             address_sets[coin] = load_funded_addresses(unique_path)
+        else:
+            log_message(f"⚠️ No unique list found for {coin.upper()} in UNIQUE_DIR", "WARN")
 
     combined_set = set.union(*address_sets.values()) if address_sets else set()
 

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -8,6 +8,8 @@ import requests
 from datetime import datetime
 from glob import glob
 
+from utils.file_utils import find_latest_funded_file
+
 from config.settings import (
     COIN_DOWNLOAD_URLS,
     DOWNLOADS_DIR,
@@ -45,9 +47,11 @@ def generate_test_csv():
 
     found_any = False
     for coin in coin_columns.keys():
-        file_path = os.path.join(DOWNLOADS_DIR, f"{coin}_funded.txt")
-        if not os.path.exists(file_path):
+        file_path = find_latest_funded_file(coin, DOWNLOADS_DIR)
+        if not file_path:
+            log_message(f"⚠️ No funded list found for {coin.upper()}.", "WARN")
             continue
+        log_message(f"📥 Using funded list {os.path.basename(file_path)} for {coin.upper()}.")
         try:
             with open(file_path, "r", encoding="utf-8") as f:
                 lines = [ln.strip() for ln in f if ln.strip()][:2]

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -1,0 +1,20 @@
+import os
+from glob import glob
+
+from config.settings import DOWNLOADS_DIR, FULL_DIR, UNIQUE_DIR
+
+
+def find_latest_funded_file(coin: str, directory: str = DOWNLOADS_DIR) -> str | None:
+    """Return the newest funded address file for ``coin`` within ``directory``.
+
+    Files are expected to follow the pattern ``{COIN}_addresses_*.txt`` where
+    ``COIN`` is the uppercase coin symbol. ``directory`` defaults to
+    :data:`config.settings.DOWNLOADS_DIR` but can be overridden when searching
+    subfolders like ``FULL_DIR`` or ``UNIQUE_DIR``.
+    """
+    pattern = os.path.join(directory, f"{coin.upper()}_addresses_*.txt")
+    files = glob(pattern)
+    if not files:
+        return None
+    latest = max(files, key=os.path.getmtime)
+    return latest


### PR DESCRIPTION
## Summary
- add `find_latest_funded_file` helper
- dynamically locate funded lists when generating test CSV
- update csv checker to use the new lookup logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68660a270de88327b8dc1b0292e98fbc