### PR TITLE
Improve downloader and add balance API

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -87,6 +87,9 @@ ENABLE_DESKTOP_WINDOW_ALERT = True
 ALERT_POPUP_COLOR_1 = "#FF0000"
 ALERT_POPUP_COLOR_2 = "#000000"
 
+# ===================== 🔗 API KEYS ==========================
+TOKENVIEW_API_KEY = os.getenv("TOKENVIEW_API_KEY", "")
+
 # ===================== 🌍 COIN SOURCES ==========================
 COIN_DOWNLOAD_URLS = {
     "btc": "http://addresses.loyce.club/Bitcoin_addresses_LATEST.txt.gz",

--- a/utils/balance_checker.py
+++ b/utils/balance_checker.py
@@ -1,0 +1,30 @@
+import requests
+from config.settings import TOKENVIEW_API_KEY
+from core.logger import log_message
+
+TOKENVIEW_URL = "https://services.tokenview.io/vipapi/addr/{coin}/{address}"
+
+def fetch_live_balance(address, coin):
+    """Fetch the current balance for a given address using the TokenView API."""
+    url = TOKENVIEW_URL.format(coin=coin, address=address)
+    headers = {}
+    if TOKENVIEW_API_KEY:
+        headers["token"] = TOKENVIEW_API_KEY
+    try:
+        resp = requests.get(url, headers=headers, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        bal_str = None
+        if isinstance(data, dict):
+            bal_str = (
+                data.get("data", {}).get("balance")
+                or data.get("data", {}).get("finalBalance")
+            )
+        if bal_str is not None:
+            try:
+                return float(bal_str)
+            except (TypeError, ValueError):
+                pass
+    except Exception as exc:
+        log_message(f"⚠️ Failed to fetch balance for {address}: {exc}", "WARN")
+    return None


### PR DESCRIPTION
## Summary
- clean funded address lists on download
- add TokenView API calls for live balance info
- log balances when matches found
- support TokenView API key in settings

## Testing
- `python -m py_compile utils/balance_checker.py core/downloader.py core/csv_checker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866112b00d08327a240030eddb5892a