### PR TITLE
Add GPU temps and backlog progress to dashboard

### DIFF
--- a/main.py
+++ b/main.py
@@ -146,6 +146,7 @@ def metrics_updater(shared_metrics=None):
                             'name': name,
                             'usage': usage,
                             'vram': vram,
+                            'temp': f"{gpu.temperature}°C" if hasattr(gpu, 'temperature') else 'N/A',
                         }
                 except Exception as e:
                     log_message(f"⚠️ GPU read failed: {e}", "WARNING")
@@ -166,7 +167,8 @@ def metrics_updater(shared_metrics=None):
                             stats['gpu_stats'][f"GPU{next_id}"] = {
                                 'name': name,
                                 'usage': 'Active (No Stats)' if next_id in ad_ids | vs_ids else 'N/A',
-                                'vram': 'Unavailable'
+                                'vram': 'Unavailable',
+                                'temp': 'N/A',
                             }
                             next_id += 1
                 except Exception as e:


### PR DESCRIPTION
## Summary
- polish layout for dashboard metrics
- expand text boxes and wrap long labels
- add backlog progress bar
- show GPU temperature in stats

## Testing
- `git ls-files '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68661edd1a8c8327825e4b2382c5d7fe