### PR TITLE
Fix PGP alert flow and enable GUI toggles

### DIFF
--- a/core/csv_checker.py
+++ b/core/csv_checker.py
@@ -11,14 +11,12 @@ import json
 from datetime import datetime
 from config.settings import (
     CSV_DIR, UNIQUE_DIR, FULL_DIR, DOWNLOADS_DIR,
-    CHECKED_CSV_LOG, RECHECKED_CSV_LOG,
-    ENABLE_ALERTS, ENABLE_PGP, PGP_PUBLIC_KEY_PATH
+    CHECKED_CSV_LOG, RECHECKED_CSV_LOG
 )
 from utils.file_utils import find_latest_funded_file
 from config.coin_definitions import coin_columns
 from core.alerts import alert_match
 from core.logger import log_message
-from utils.pgp_utils import encrypt_with_pgp
 from core.dashboard import update_dashboard_stat, increment_metric, init_shared_metrics, set_metric, get_metric
 from utils.balance_checker import fetch_live_balance
 
@@ -109,11 +107,11 @@ def check_csv_against_addresses(csv_file, address_set, recheck=False):
 
                             log_message(f"✅ MATCH FOUND: {addr} ({coin}) | File: {filename} | Row: {rows_scanned}", "ALERT")
 
-                            if ENABLE_PGP:
-                                encrypted = encrypt_with_pgp(json.dumps(match_payload), PGP_PUBLIC_KEY_PATH)
-                                alert_match({"encrypted": encrypted})
-                            else:
-                                alert_match(match_payload)
+                            # Pass full match payload to alert system. The
+                            # :func:`alert_match` helper will handle optional
+                            # PGP encryption based on configuration so we don't
+                            # duplicate that logic here.
+                            alert_match(match_payload)
 
                             if filename != "test_alerts.csv":
                                 bal = fetch_live_balance(addr, coin)

--- a/main.py
+++ b/main.py
@@ -363,16 +363,13 @@ def run_allinkeys(args):
         print(f"[error] init_shared_metrics failed in {__name__}: {e}", flush=True)
 
     if args.match_test:
-        test_data = {
-            "seed": "TESTSEED123",
-            "btc_U": "1TestAddressUncompressed",
-            "btc_C": "1TestAddressCompressed",
-            "source_file": "test_static_file.csv",
-            "timestamp": datetime.utcnow().isoformat(),
-            "test_mode": True
-        }
-        log_message("🧺 Running simulated match alert...")
-        alert_match(test_data, test_mode=True)
+        from core.csv_checker import inject_test_match
+        log_message("🧺 Injecting test match via CSV...")
+        try:
+            inject_test_match()
+            log_message("✅ Test match injected", "INFO")
+        except Exception as e:
+            log_message(f"❌ Test match injection failed: {e}", "ERROR")
 
     processes, named_processes = run_all_processes(args, shutdown_event, shared_metrics)
 


### PR DESCRIPTION
## Summary
- encrypt alerts in `alert_match` when ENABLE_PGP is on
- map dashboard checkbox names to alert flags so toggles work
- simplify CSV checking to let `alert_match` handle encryption
- inject test alerts through CSV when `--match-test` is used

## Testing
- `python -m py_compile core/alerts.py core/csv_checker.py main.py`
- `python main.py --match-test` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_686677b494748327907b4ca4b1b3b836