### PR TITLE
Fix alert logging and dashboard controls

### DIFF
--- a/core/dashboard.py
+++ b/core/dashboard.py
@@ -15,6 +15,29 @@ THREAD_HEALTH = {
     "alerts": True
 }
 
+# Control events propagated from the main process
+shutdown_event = None
+pause_event = None
+
+# Simple helpers for modules to report alive/dead status
+def set_thread_health(name, running: bool):
+    THREAD_HEALTH[name] = running
+    update_dashboard_stat("thread_health_flags", THREAD_HEALTH.copy())
+
+
+def register_control_events(shutdown, pause):
+    global shutdown_event, pause_event
+    shutdown_event = shutdown
+    pause_event = pause
+
+
+def get_shutdown_event():
+    return shutdown_event
+
+
+def get_pause_event():
+    return pause_event
+
 # Delayed initialization of Manager and Lock to avoid multiprocessing import issues on Windows
 manager = None
 metrics_lock = None

--- a/main.py
+++ b/main.py
@@ -295,7 +295,7 @@ def run_all_processes(args, shutdown_event, shared_metrics):
 
     if ENABLE_BACKLOG_CONVERSION and not args.skip_backlog:
         try:
-            p = start_altcoin_conversion_process(shutdown_event, shared_metrics)
+            p = start_altcoin_conversion_process(shutdown_event, shared_metrics, pause_event)
             log_message("[Started] Altcoin derive subprocess", "INFO")
             processes.append(p)
             named_processes.append(("altcoin", p))
@@ -348,6 +348,9 @@ def run_allinkeys(args):
     if not os.path.exists(test_csv):
         generate_test_csv()
     shutdown_event = multiprocessing.Event()
+    pause_event = multiprocessing.Event()
+    from core.dashboard import register_control_events
+    register_control_events(shutdown_event, pause_event)
 
     # Use dashboard's helper to create a Manager-backed shared metrics dict with
     # an associated lock.  Previously this file manually created its own


### PR DESCRIPTION
## Summary
- ensure PGP failures fall back to plaintext alerts and correct match counts
- write matches to timestamped log files
- wire up dashboard control events and thread health reporting
- persist alert checkbox state and show process health in GUI
- support pause/stop events for keygen, backlog and altcoin derive threads
- run altcoin backlog conversions concurrently

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868a7f827d083279d9a3138fad8597f