### PR TITLE
Fix pause events and CSV field limit

### DIFF
--- a/core/alerts.py
+++ b/core/alerts.py
@@ -299,11 +299,15 @@ def alert_match(match_data, test_mode=False):
         log_message(f"❌ Local match logging error: {e}", "ERROR")
 
 
-def trigger_startup_alerts():
+def trigger_startup_alerts(shared_metrics=None):
     """
     Sends startup alerts through configured channels.
     """
-    from core.dashboard import set_metric
+    from core.dashboard import set_metric, init_shared_metrics
+    try:
+        init_shared_metrics(shared_metrics)
+    except Exception:
+        pass
     if not ENABLE_ALERTS:
         log_message("🚫 Alerts are disabled in config.", "INFO")
         return

--- a/core/csv_checker.py
+++ b/core/csv_checker.py
@@ -10,8 +10,8 @@ import io
 import json
 from datetime import datetime
 
-# Increase CSV field size limit to handle large entries (up to 10MB)
-csv.field_size_limit(10 * 1024 * 1024)
+# Increase CSV field size limit to handle large entries (up to 100MB)
+csv.field_size_limit(100 * 1024 * 1024)
 from config.settings import (
     CSV_DIR, UNIQUE_DIR, FULL_DIR, DOWNLOADS_DIR,
     CHECKED_CSV_LOG, RECHECKED_CSV_LOG,
@@ -203,9 +203,11 @@ def check_csv_against_addresses(csv_file, address_set, recheck=False):
         log_message(f"❌ Error reading {filename}: {str(e)}", "ERROR")
         return []
 
-def check_csvs_day_one(shared_metrics=None):
+def check_csvs_day_one(shared_metrics=None, shutdown_event=None, pause_event=None):
     try:
         init_shared_metrics(shared_metrics)
+        from core.dashboard import register_control_events
+        register_control_events(shutdown_event, pause_event)
         set_metric("status.csv_check", True)
         set_metric("csv_checked_today", 0)
         set_metric("addresses_checked_today", {c: 0 for c in coin_columns})
@@ -247,9 +249,11 @@ def check_csvs_day_one(shared_metrics=None):
         pass
 
 
-def check_csvs(shared_metrics=None):
+def check_csvs(shared_metrics=None, shutdown_event=None, pause_event=None):
     try:
         init_shared_metrics(shared_metrics)
+        from core.dashboard import register_control_events
+        register_control_events(shutdown_event, pause_event)
         set_metric("status.csv_recheck", True)
         set_metric("csv_rechecked_today", 0)
         set_metric("addresses_checked_today", {c: 0 for c in coin_columns})

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -163,12 +163,14 @@ def run_vanitysearch_stream(initial_seed_int, batch_id, index_within_batch):
 from core.dashboard import init_shared_metrics, set_metric, increment_metric, get_metric
 
 
-def start_keygen_loop(shared_metrics=None):
+def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None):
     try:
         init_shared_metrics(shared_metrics)
         print("[debug] Shared metrics initialized for", __name__, flush=True)
     except Exception as e:
         print(f"[error] init_shared_metrics failed in {__name__}: {e}", flush=True)
+    from core.dashboard import register_control_events
+    register_control_events(shutdown_event, pause_event)
     if not os.path.exists(VANITY_OUTPUT_DIR):
         os.makedirs(VANITY_OUTPUT_DIR)
 


### PR DESCRIPTION
## Summary
- wire shutdown and pause events to keygen and CSV checker subprocesses
- initialize metrics in alerts subprocess
- enlarge CSV field size limit to handle large rows
- propagate pause event through process launcher

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686acff7788883278a68852e07cadcb3