### PR TITLE
Fix dashboard metrics update

### DIFF
--- a/core/backlog.py
+++ b/core/backlog.py
@@ -54,14 +54,15 @@ def is_file_still_writing(path, delay=2.0):
         return True
 
 
-def start_backlog_conversion_loop():
+def start_backlog_conversion_loop(shared_metrics=None, shutdown_event=None, pause_event=None):
     """
     Monitors VANITY_OUTPUT_DIR for .txt files and converts to .csv if ready.
     Skips files that are too small, locked, or recently modified.
     """
-    from core.dashboard import set_metric, init_shared_metrics
+    from core.dashboard import set_metric, init_shared_metrics, register_control_events
     try:
-        init_shared_metrics(None)
+        init_shared_metrics(shared_metrics)
+        register_control_events(shutdown_event, pause_event)
     except Exception:
         pass
     from core.dashboard import set_thread_health

--- a/core/dashboard.py
+++ b/core/dashboard.py
@@ -186,12 +186,24 @@ def _update_stat_internal(key, value=None):
 
     if isinstance(key, dict) and value is None:
         for k, v in key.items():
-            metrics[k] = v
-    else:
-        if value is None:
-            print(f"⚠️ update_dashboard_stat('{key}') called without a value. Defaulting to 'N/A'", flush=True)
-            value = "N/A"
-        metrics[key] = value
+            _update_stat_internal(k, v)
+        return
+
+    if value is None:
+        print(
+            f"⚠️ update_dashboard_stat('{key}') called without a value. Defaulting to 'N/A'",
+            flush=True,
+        )
+        value = "N/A"
+
+    # Support dotted keys for nested dict updates
+    if isinstance(key, str) and "." in key:
+        top, sub = key.split(".", 1)
+        if isinstance(metrics.get(top), dict):
+            metrics[top][sub] = value
+            return
+
+    metrics[key] = value
 
 def increment_metric(key, amount=1):
     if not metrics_lock:


### PR DESCRIPTION
## Summary
- handle dotted metric keys for nested updates
- initialize backlog loop with shared metrics and events

## Testing
- `python -m py_compile core/dashboard.py core/backlog.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ad67f986c8327bdd6ba99cc052925