### PR TITLE
Fix altcoin process spawn and pause handling

### DIFF
--- a/core/altcoin_derive.py
+++ b/core/altcoin_derive.py
@@ -580,7 +580,10 @@ def start_altcoin_conversion_process(shared_shutdown_event, shared_metrics=None,
         args=(shared_shutdown_event, shared_metrics, pause_event),
         name="AltcoinConverter"
     )
-    process.daemon = True
+    # This process launches a ``ProcessPoolExecutor`` for parallel conversions
+    # and therefore cannot be a daemon.  Marking it as non-daemonic avoids
+    # ``daemonic processes are not allowed to have children`` errors.
+    process.daemon = False
     process.start()
     log_message("🚀 Altcoin derive subprocess started...", "INFO")
     return process


### PR DESCRIPTION
## Summary
- gracefully skip VanitySearch launch when paused
- remove empty output files and report failure in keygen
- avoid advancing keygen index when run aborted
- launch altcoin conversion as non-daemon so it can spawn children

## Testing
- `flake8 core/altcoin_derive.py core/keygen.py` *(fails: E501, F401, etc.)*
- `pytest -q` *(no tests found)*
- `python -m py_compile core/keygen.py core/altcoin_derive.py`

------
https://chatgpt.com/codex/tasks/task_e_686af642d61883279d804fc953d8d96d