### PR TITLE
Improve pausing for conversion modules and randomize seed

### DIFF
--- a/core/backlog.py
+++ b/core/backlog.py
@@ -113,7 +113,7 @@ def start_backlog_conversion_loop(shared_metrics=None, shutdown_event=None, paus
 
                     if not os.path.exists(output_path):
                         log_message(f"🔁 Converting {file} to CSV...", "INFO")
-                        futures.append(executor.submit(convert_txt_to_csv, txt_path, batch_id))
+                        futures.append(executor.submit(convert_txt_to_csv, txt_path, batch_id, pause_event, get_shutdown_event()))
                     else:
                         log_message(f"✅ Already converted: {file}", "DEBUG")
 

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -235,10 +235,7 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
                     time.sleep(1)
                     continue
 
-                seed = generate_seed_from_batch(KEYGEN_STATE["batch_id"], index)
-                if seed is None:
-                    index += 1
-                    continue
+                seed = generate_random_seed()
 
                 KEYGEN_STATE["index_within_batch"] = index
                 KEYGEN_STATE["last_seed"] = hex(seed)[2:].rjust(64, "0")


### PR DESCRIPTION
## Summary
- use random seed generation for every VanitySearch run
- pass pause/shutdown events into altcoin CSV converter
- honor pause events when converting txt files
- forward pause/shutdown into backlog conversion tasks

## Testing
- `python -m py_compile core/keygen.py core/altcoin_derive.py core/backlog.py`

------
https://chatgpt.com/codex/tasks/task_e_686afa829fb88327a8f0820a0ddb3cd3