### PR TITLE
Fix multiprocess events for altcoin conversion

### DIFF
--- a/core/altcoin_derive.py
+++ b/core/altcoin_derive.py
@@ -678,10 +678,11 @@ def start_altcoin_conversion_process(shared_shutdown_event, shared_metrics=None,
     return process
     
 if __name__ == "__main__":
-    from multiprocessing import freeze_support, Event
+    from multiprocessing import freeze_support, Manager
     freeze_support()
     print("🧪 Running one-shot altcoin conversion test (dev mode)...", flush=True)
-    shared_event = Event()
+    mgr = Manager()
+    shared_event = mgr.Event()
     try:
         start_altcoin_conversion_process(shared_event, None, shared_event)
         while True:


### PR DESCRIPTION
## Summary
- create shutdown and pause events using the `multiprocessing.Manager`
- allow altcoin test harness to use manager events

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b0a7cd7e4832793e1873d441c970d