### PR TITLE
Make downloader concurrent

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -7,6 +7,7 @@ import csv
 import requests
 from datetime import datetime
 from glob import glob
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from utils.file_utils import find_latest_funded_file
 
@@ -105,86 +106,95 @@ def generate_test_csv():
 
     return test_csv_path
 
-def download_and_compare_address_lists():
-    """
-    Downloads and processes funded address lists for each coin.
-    Creates full and unique lists, keeps only the 2 latest files.
-    """
-    for coin, url in COIN_DOWNLOAD_URLS.items():
-        try:
-            now = datetime.utcnow().strftime("%Y-%m-%d_%H-%M-%S")
-            today_prefix = datetime.utcnow().strftime("%Y-%m-%d")
-            pattern_today = os.path.join(
-                DOWNLOADS_DIR, f"{coin.upper()}_addresses_{today_prefix}*.txt"
+def _download_single_coin(coin: str, url: str) -> None:
+    """Handle downloading and processing for a single coin."""
+    try:
+        now = datetime.utcnow().strftime("%Y-%m-%d_%H-%M-%S")
+        today_prefix = datetime.utcnow().strftime("%Y-%m-%d")
+        pattern_today = os.path.join(
+            DOWNLOADS_DIR, f"{coin.upper()}_addresses_{today_prefix}*.txt"
+        )
+        if glob(pattern_today):
+            log_message(f"{coin.upper()}: Already downloaded today, skipping")
+            return
+        output_full = os.path.join(
+            DOWNLOADS_DIR, f"{coin.upper()}_addresses_{now}.txt"
+        )
+        output_unique = os.path.join(
+            DOWNLOADS_DIR, f"{coin.upper()}_UNIQUE_addresses_{now}.txt"
+        )
+        gz_path = output_full + ".gz"
+
+        r = requests.get(url, stream=True, timeout=30)
+        r.raise_for_status()
+        with open(gz_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                f.write(chunk)
+        log_message(f"{coin.upper()}: Download complete")
+
+        with open(gz_path, "rb") as test_f:
+            magic = test_f.read(2)
+        is_gzipped = magic == b"\x1f\x8b"
+
+        if is_gzipped:
+            with gzip.open(gz_path, "rb") as f_in, open(output_full, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+            os.remove(gz_path)
+            log_message(f"{coin.upper()}: Decompressed to {output_full}")
+        else:
+            shutil.move(gz_path, output_full)
+            log_message(f"{coin.upper()}: File was not gzipped. Saved as-is.")
+
+        if coin == "btc":
+            with open(output_full, "r", encoding="utf-8") as f:
+                filtered = [line for line in f if line.startswith("1")]
+            with open(output_full, "w", encoding="utf-8") as f:
+                f.writelines(filtered)
+            log_message(f"{coin.upper()}: Filtered for addresses starting with '1'")
+
+        clean_address_file(output_full)
+
+        previous_files = sorted(
+            glob(os.path.join(DOWNLOADS_DIR, f"{coin.upper()}_addresses_*.txt"))
+        )
+        if len(previous_files) >= 2:
+            previous_file = previous_files[-2]
+            with open(previous_file, "r", encoding="utf-8") as f:
+                old_addrs = set(parse_address_lines(f))
+
+            with open(output_full, "r", encoding="utf-8") as f:
+                new_addrs = set(parse_address_lines(f))
+
+            newly_funded = sorted(new_addrs - old_addrs)
+            with open(output_unique, "w", encoding="utf-8") as f:
+                f.write("\n".join(newly_funded))
+            clean_address_file(output_unique)
+            log_message(
+                f"{coin.upper()}: {len(newly_funded)} new addresses written to {output_unique}"
             )
-            if glob(pattern_today):
-                log_message(f"{coin.upper()}: Already downloaded today, skipping")
-                continue
-            output_full = os.path.join(DOWNLOADS_DIR, f"{coin.upper()}_addresses_{now}.txt")
-            output_unique = os.path.join(DOWNLOADS_DIR, f"{coin.upper()}_UNIQUE_addresses_{now}.txt")
-            gz_path = output_full + ".gz"
 
-            # Download file
-            r = requests.get(url, stream=True, timeout=30)
-            r.raise_for_status()
-            with open(gz_path, 'wb') as f:
-                for chunk in r.iter_content(chunk_size=8192):
-                    f.write(chunk)
-            log_message(f"{coin.upper()}: Download complete")
+        for pattern in [
+            f"{coin.upper()}_addresses_*.txt",
+            f"{coin.upper()}_UNIQUE_addresses_*.txt",
+        ]:
+            files = sorted(glob(os.path.join(DOWNLOADS_DIR, pattern)))
+            while len(files) > MAX_DAILY_FILES_PER_COIN:
+                to_delete = files.pop(0)
+                os.remove(to_delete)
+                log_message(f"{coin.upper()}: Deleted old file {to_delete}")
 
-            # Check for GZIP magic header
-            with open(gz_path, 'rb') as test_f:
-                magic = test_f.read(2)
-            is_gzipped = magic == b'\x1f\x8b'
+    except Exception as e:
+        log_message(f"❌ {coin.upper()} download failed: {str(e)}", "ERROR")
 
-            if is_gzipped:
-                # Decompress .gz file
-                with gzip.open(gz_path, 'rb') as f_in, open(output_full, 'wb') as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-                os.remove(gz_path)
-                log_message(f"{coin.upper()}: Decompressed to {output_full}")
-            else:
-                # Treat as raw text file
-                shutil.move(gz_path, output_full)
-                log_message(f"{coin.upper()}: File was not gzipped. Saved as-is.")
 
-            # BTC: Filter only addresses starting with '1'
-            if coin == "btc":
-                with open(output_full, 'r', encoding='utf-8') as f:
-                    filtered = [line for line in f if line.startswith("1")]
-                with open(output_full, 'w', encoding='utf-8') as f:
-                    f.writelines(filtered)
-                log_message(f"{coin.upper()}: Filtered for addresses starting with '1'")
+def download_and_compare_address_lists() -> None:
+    """Download and process all funded address lists concurrently."""
+    os.makedirs(DOWNLOADS_DIR, exist_ok=True)
 
-            # Clean downloaded file to keep addresses only
-            clean_address_file(output_full)
+    with ThreadPoolExecutor(max_workers=len(COIN_DOWNLOAD_URLS)) as executor:
+        futures = [executor.submit(_download_single_coin, coin, url)
+                   for coin, url in COIN_DOWNLOAD_URLS.items()]
+        for future in as_completed(futures):
+            future.result()
 
-            # Compare with previous file
-            previous_files = sorted(glob(os.path.join(DOWNLOADS_DIR, f"{coin.upper()}_addresses_*.txt")))
-            if len(previous_files) >= 2:
-                previous_file = previous_files[-2]
-                with open(previous_file, 'r', encoding='utf-8') as f:
-                    old_addrs = set(parse_address_lines(f))
-
-                with open(output_full, 'r', encoding='utf-8') as f:
-                    new_addrs = set(parse_address_lines(f))
-
-                newly_funded = sorted(new_addrs - old_addrs)
-                with open(output_unique, 'w', encoding='utf-8') as f:
-                    f.write('\n'.join(newly_funded))
-                clean_address_file(output_unique)
-                log_message(f"{coin.upper()}: {len(newly_funded)} new addresses written to {output_unique}")
-
-            # Prune excess files
-            for pattern in [f"{coin.upper()}_addresses_*.txt", f"{coin.upper()}_UNIQUE_addresses_*.txt"]:
-                files = sorted(glob(os.path.join(DOWNLOADS_DIR, pattern)))
-                while len(files) > MAX_DAILY_FILES_PER_COIN:
-                    to_delete = files.pop(0)
-                    os.remove(to_delete)
-                    log_message(f"{coin.upper()}: Deleted old file {to_delete}")
-
-        except Exception as e:
-            log_message(f"❌ {coin.upper()} download failed: {str(e)}", "ERROR")
-
-    # Generate test CSV even when downloads are skipped
     generate_test_csv()


### PR DESCRIPTION
## Summary
- enable multithreaded downloads using ThreadPoolExecutor
- keep existing file cleanup and test CSV generation logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b47e89da88327a8a717d5fc9200ca