### PR TITLE
Use separate full and unique funded lists

### DIFF
--- a/core/csv_checker.py
+++ b/core/csv_checker.py
@@ -288,7 +288,7 @@ def check_csvs_day_one(shared_metrics=None, shutdown_event=None, pause_event=Non
 
     address_sets = {}
     for coin, columns in coin_columns.items():
-        full_path = find_latest_funded_file(coin, directory=DOWNLOADS_DIR)
+        full_path = find_latest_funded_file(coin, directory=DOWNLOADS_DIR, unique=False)
         if full_path:
             log_message(f"🔎 Using funded list {os.path.basename(full_path)} for {coin.upper()}.")
             address_sets[coin] = load_funded_addresses(full_path)
@@ -338,7 +338,7 @@ def check_csvs(shared_metrics=None, shutdown_event=None, pause_event=None, safe_
 
     address_sets = {}
     for coin, columns in coin_columns.items():
-        unique_path = find_latest_funded_file(coin, directory=DOWNLOADS_DIR)
+        unique_path = find_latest_funded_file(coin, directory=DOWNLOADS_DIR, unique=True)
         if unique_path:
             log_message(f"🔎 Using unique list {os.path.basename(unique_path)} for {coin.upper()}.")
             address_sets[coin] = load_funded_addresses(unique_path)

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -4,15 +4,27 @@ from glob import glob
 from config.settings import DOWNLOADS_DIR, FULL_DIR, UNIQUE_DIR
 
 
-def find_latest_funded_file(coin: str, directory: str = DOWNLOADS_DIR) -> str | None:
-    """Return the newest funded address file for ``coin`` within ``directory``.
+def find_latest_funded_file(
+    coin: str,
+    directory: str = DOWNLOADS_DIR,
+    *,
+    unique: bool = False,
+) -> str | None:
+    """Return the newest funded address list for ``coin``.
 
-    Files are expected to follow the pattern ``{COIN}_addresses_*.txt`` where
-    ``COIN`` is the uppercase coin symbol. ``directory`` defaults to
-    :data:`config.settings.DOWNLOADS_DIR` but can be overridden when searching
-    subfolders like ``FULL_DIR`` or ``UNIQUE_DIR``.
+    Parameters
+    ----------
+    coin : str
+        The coin symbol to search for (e.g. ``btc``).
+    directory : str, optional
+        Directory to search. Defaults to :data:`DOWNLOADS_DIR`.
+    unique : bool, optional
+        If ``True``, search for ``*_UNIQUE_addresses_*`` files instead of the
+        full ``*_addresses_*`` lists.
     """
-    pattern = os.path.join(directory, f"{coin.upper()}_addresses_*.txt")
+
+    suffix = "_UNIQUE_addresses_" if unique else "_addresses_"
+    pattern = os.path.join(directory, f"{coin.upper()}{suffix}*.txt")
     files = glob(pattern)
     if not files:
         return None


### PR DESCRIPTION
## Summary
- distinguish between full and unique funded address lists
- check CSVs against the latest full list on day one
- recheck CSVs against the latest UNIQUE list after day one

## Testing
- `python -m py_compile utils/file_utils.py core/csv_checker.py`

------
https://chatgpt.com/codex/tasks/task_e_6871a36c2de48327a6261865749110b2