### PR TITLE
Fix dashboard metrics refresh and logging

### DIFF
--- a/core/csv_checker.py
+++ b/core/csv_checker.py
@@ -283,6 +283,7 @@ def check_csvs_day_one(shared_metrics=None, shutdown_event=None, pause_event=Non
         from core.dashboard import set_thread_health
         set_thread_health("csv_check", True)
         print("[debug] Shared metrics initialized for", __name__, flush=True)
+        log_message("🟢 CSV day-one checker started", "DEBUG")
     except Exception as e:
         print(f"[error] init_shared_metrics failed in {__name__}: {e}", flush=True)
 
@@ -333,6 +334,7 @@ def check_csvs(shared_metrics=None, shutdown_event=None, pause_event=None, safe_
         from core.dashboard import set_thread_health
         set_thread_health("csv_recheck", True)
         print("[debug] Shared metrics initialized for", __name__, flush=True)
+        log_message("🟢 CSV recheck checker started", "DEBUG")
     except Exception as e:
         print(f"[error] init_shared_metrics failed in {__name__}: {e}", flush=True)
 


### PR DESCRIPTION
## Summary
- convert manager proxy objects before returning metrics
- rotate debug logs to prevent huge log files
- add debug start logs for csv checkers
- refactor dashboard metric refresh and display dictionaries per line

## Testing
- `python -m py_compile ui/dashboard_gui.py core/logger.py core/dashboard.py core/csv_checker.py`

------
https://chatgpt.com/codex/tasks/task_e_6871b5584e0c8327873ff11152c51736