### PR TITLE
Ensure matches are always logged

### DIFF
--- a/core/alerts.py
+++ b/core/alerts.py
@@ -140,6 +140,7 @@ def alert_match(match_data, test_mode=False):
     alert_type = "TEST MATCH" if test_mode else "MATCH FOUND"
 
     match_text = f"[{timestamp}] {alert_type}!\nCoin: {coin}\nAddress: {address}\nCSV: {csv_file}\nWIF: {privkey}"
+    log_message(f"🎯 Match found: {json.dumps(match_data)}", "INFO")
     log_message(f"🚨 {alert_type}: {address} (File: {csv_file})")
 
     # 🖥️ Desktop Window Alert

--- a/core/csv_checker.py
+++ b/core/csv_checker.py
@@ -268,7 +268,10 @@ def check_csv_against_addresses(csv_file, address_sets, recheck=False, safe_mode
         log_message(f"❌ Error reading {filename}: {str(e)}", "ERROR")
         return []
 
-def check_csvs_day_one(shared_metrics=None, shutdown_event=None, pause_event=None, safe_mode=False):
+from core.logger import initialize_logging
+
+def check_csvs_day_one(shared_metrics=None, shutdown_event=None, pause_event=None, safe_mode=False, log_q=None):
+    initialize_logging(log_q)
     try:
         init_shared_metrics(shared_metrics)
         from core.dashboard import register_control_events
@@ -319,7 +322,8 @@ def check_csvs_day_one(shared_metrics=None, shutdown_event=None, pause_event=Non
         pass
 
 
-def check_csvs(shared_metrics=None, shutdown_event=None, pause_event=None, safe_mode=False):
+def check_csvs(shared_metrics=None, shutdown_event=None, pause_event=None, safe_mode=False, log_q=None):
+    initialize_logging(log_q)
     try:
         init_shared_metrics(shared_metrics)
         from core.dashboard import register_control_events
@@ -390,9 +394,11 @@ if __name__ == "__main__":
     parser.add_argument("--threshold", type=int, default=10_000_000, help="Byte threshold for --scan")
     args = parser.parse_args()
 
+    from core.logger import start_listener, log_queue
+    start_listener()
     if args.scan:
         scan_csv_for_oversized_lines(args.scan, threshold=args.threshold)
     elif args.recheck:
-        check_csvs(safe_mode=args.safe)
+        check_csvs(safe_mode=args.safe, log_q=log_queue)
     else:
-        check_csvs_day_one(safe_mode=args.safe)
+        check_csvs_day_one(safe_mode=args.safe, log_q=log_queue)

--- a/core/logger.py
+++ b/core/logger.py
@@ -23,6 +23,16 @@ def _ensure_queue():
         log_queue = multiprocessing.Queue(-1)
     return log_queue
 
+def initialize_logging(queue: mp_queues.Queue | None = None) -> mp_queues.Queue:
+    """Initialize logging for a subprocess using the shared queue."""
+    global log_queue, _logger
+    if queue is not None:
+        log_queue = queue
+    elif log_queue is None:
+        log_queue = multiprocessing.Queue(-1)
+    _logger = None
+    return log_queue
+
 def start_listener():
     """Start the multiprocessing log listener."""
     global _listener


### PR DESCRIPTION
## Summary
- ensure each alert logs a match before alerts fire
- add `initialize_logging` helper and use shared queue in sub processes
- wire logging queue through csv checker and altcoin derive

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from core.logger import start_listener, stop_listener, DEBUG_LOG_PATH
start_listener()
from core.alerts import alert_match
alert_match({'timestamp':'2025-07-12 00:42:10','coin':'BTC','address':'1abcde','csv_file':'keys_batch_00045.csv','privkey':'WIFTEST'}, test_mode=True)
stop_listener()
print('done')
print(open(DEBUG_LOG_PATH).read().splitlines()[-2:])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6871e502418c8327beebaed63ca8f4fe