### PR TITLE
Improve CSV checker reliability with checkpoints

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -31,6 +31,8 @@ CHECKPOINT_PATH = os.path.join(LOG_DIR, "restore_checkpoint.json")
 # Track which CSVs have been processed
 CHECKED_CSV_LOG = os.path.join(LOG_DIR, "checked_csvs.txt")
 RECHECKED_CSV_LOG = os.path.join(LOG_DIR, "rechecked_csvs.txt")
+# Track per-file progress for the CSV checker
+CSV_CHECKPOINT_STATE = os.path.join(LOG_DIR, "csv_checker_state.json")
 # Alias for backward compatibility
 DOWNLOAD_DIR = DOWNLOADS_DIR
 CHECKPOINT_FILE = os.path.join(BASE_DIR, "checkpoint.json")


### PR DESCRIPTION
## Summary
- add `CSV_CHECKPOINT_STATE` path to settings
- persist CSV checker state for daily resume
- resume scanning from last row processed
- log progress during scanning
- initialize state for unique recheck mode

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688656d52e808327b94c606dc33d58ab