### PR TITLE
Fix lifetime metrics and module controls

### DIFF
--- a/core/alerts.py
+++ b/core/alerts.py
@@ -174,6 +174,7 @@ def alert_match(match_data, test_mode=False):
             root.mainloop()
             log_message("✅ Desktop popup displayed.", "INFO")
             increment_metric("alerts_sent_today.popup")
+            increment_metric("alerts_sent_lifetime.popup")
         except Exception as e:
             log_message(f"❌ Desktop alert error: {e}", "ERROR")
 
@@ -184,6 +185,7 @@ def alert_match(match_data, test_mode=False):
             _start_audio_worker()
             audio_queue.put(ALERT_SOUND_FILE)
             increment_metric("alerts_sent_today.popup")
+            increment_metric("alerts_sent_lifetime.popup")
         else:
             log_message(f"❌ Sound file not found: {ALERT_SOUND_FILE}", "ERROR")
 
@@ -203,6 +205,7 @@ def alert_match(match_data, test_mode=False):
             server.quit()
             log_message("📧 Email alert sent.", "INFO")
             increment_metric("alerts_sent_today.email")
+            increment_metric("alerts_sent_lifetime.email")
         except Exception as e:
             log_message(f"❌ Email alert error: {e}", "WARNING")
 
@@ -214,6 +217,7 @@ def alert_match(match_data, test_mode=False):
             if resp.ok and resp.json().get("ok"):
                 log_message("📨 Telegram alert sent.", "INFO")
                 increment_metric("alerts_sent_today.telegram")
+                increment_metric("alerts_sent_lifetime.telegram")
             else:
                 log_message(f"❌ Telegram alert failed: {resp.text}", "ERROR")
         except Exception as e:
@@ -228,6 +232,7 @@ def alert_match(match_data, test_mode=False):
             client.messages.create(body=match_text, from_=TWILIO_FROM, to=TWILIO_TO_SMS)
             log_message("📲 SMS alert sent.", "INFO")
             increment_metric("alerts_sent_today.sms")
+            increment_metric("alerts_sent_lifetime.sms")
         except Exception as e:
             log_message(f"❌ SMS alert error: {e}", "WARNING")
 
@@ -244,6 +249,7 @@ def alert_match(match_data, test_mode=False):
             )
             log_message("📞 Phone call alert triggered.", "INFO")
             increment_metric("alerts_sent_today.phone")
+            increment_metric("alerts_sent_lifetime.phone")
         except Exception as e:
             log_message(f"❌ Phone call error: {e}", "WARNING")
 
@@ -255,6 +261,7 @@ def alert_match(match_data, test_mode=False):
             if resp.ok:
                 log_message("💬 Discord alert sent.", "INFO")
                 increment_metric("alerts_sent_today.discord")
+                increment_metric("alerts_sent_lifetime.discord")
             else:
                 log_message(f"❌ Discord alert failed: {resp.text}", "ERROR")
         except Exception as e:
@@ -272,6 +279,7 @@ def alert_match(match_data, test_mode=False):
             if resp.ok:
                 log_message("🏠 Home Assistant alert sent.", "INFO")
                 increment_metric("alerts_sent_today.home_assistant")
+                increment_metric("alerts_sent_lifetime.home_assistant")
             else:
                 log_message(f"❌ Home Assistant alert failed: {resp.text}", "ERROR")
         except Exception as e:
@@ -291,6 +299,7 @@ def alert_match(match_data, test_mode=False):
                 f.write(b64_encrypted)
             log_message("☁ Encrypted match uploaded locally.", "INFO")
             increment_metric("alerts_sent_today.cloud")
+            increment_metric("alerts_sent_lifetime.cloud")
         except Exception as e:
             log_message(f"❌ PGP/cloud upload error: {e}", "ERROR")
 
@@ -303,6 +312,7 @@ def alert_match(match_data, test_mode=False):
             f.write(json.dumps(match_data) + "\n")
         log_message("📝 Match written to local log.", "INFO")
         increment_metric("alerts_sent_today.file")
+        increment_metric("alerts_sent_lifetime.file")
     except Exception as e:
         log_message(f"❌ Local match logging error: {e}", "ERROR")
 

--- a/core/csv_checker.py
+++ b/core/csv_checker.py
@@ -122,7 +122,7 @@ def load_funded_addresses(file_path):
     with open(file_path, "r") as f:
         return set(normalize_address(line.strip()) for line in f.readlines())
 
-def check_csv_against_addresses(csv_file, address_sets, recheck=False, safe_mode=False, pause_event=None, start_row=0, state=None):
+def check_csv_against_addresses(csv_file, address_sets, recheck=False, safe_mode=False, pause_event=None, shutdown_event=None, start_row=0, state=None):
     new_matches = set()
     all_matches = []
     filename = os.path.basename(csv_file)
@@ -176,6 +176,8 @@ def check_csv_against_addresses(csv_file, address_sets, recheck=False, safe_mode
 
             try:
                 for row_num, row in enumerate(reader, start=1):
+                    if shutdown_event and shutdown_event.is_set():
+                        break
                     if row_num <= start_row:
                         continue
                     if pause_event and pause_event.is_set():
@@ -355,6 +357,8 @@ def check_csvs_day_one(shared_metrics=None, shutdown_event=None, pause_event=Non
 
     from core.dashboard import get_pause_event
     for filename in os.listdir(CSV_DIR):
+        if shutdown_event and shutdown_event.is_set():
+            break
         if filename.endswith(".partial.csv"):
             final = filename.replace(".partial.csv", ".csv")
             if os.path.exists(os.path.join(CSV_DIR, final)):
@@ -372,6 +376,7 @@ def check_csvs_day_one(shared_metrics=None, shutdown_event=None, pause_event=Non
             address_sets,
             safe_mode=safe_mode,
             pause_event=pause_event,
+            shutdown_event=shutdown_event,
             start_row=start_row,
             state=state,
         )
@@ -416,6 +421,8 @@ def check_csvs(shared_metrics=None, shutdown_event=None, pause_event=None, safe_
 
     from core.dashboard import get_pause_event
     for filename in os.listdir(CSV_DIR):
+        if shutdown_event and shutdown_event.is_set():
+            break
         if filename.endswith(".partial.csv"):
             final = filename.replace(".partial.csv", ".csv")
             if os.path.exists(os.path.join(CSV_DIR, final)):
@@ -434,6 +441,7 @@ def check_csvs(shared_metrics=None, shutdown_event=None, pause_event=None, safe_
             recheck=True,
             safe_mode=safe_mode,
             pause_event=pause_event,
+            shutdown_event=shutdown_event,
             start_row=start_row,
             state=state,
         )

--- a/core/dashboard.py
+++ b/core/dashboard.py
@@ -35,6 +35,20 @@ pause_event = None
 module_pause_events = {}
 module_shutdown_events = {}
 
+# Alert channels mirrored from core.alerts to avoid circular import
+ALERT_CHANNELS = [
+    "email",
+    "telegram",
+    "popup",
+    "sms",
+    "file",
+    "cloud",
+    "phone",
+    "discord",
+    "webhook",
+    "home_assistant",
+]
+
 # Lifetime metrics persistence
 METRICS_LIFETIME_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'metrics_lifetime.json'))
 LIFETIME_KEYS = {
@@ -45,6 +59,7 @@ LIFETIME_KEYS = {
     'matches_found_lifetime',
     'addresses_checked_lifetime',
     'addresses_generated_lifetime',
+    'alerts_sent_lifetime',
     'lifetime_start_timestamp',
 }
 
@@ -225,7 +240,8 @@ def _default_metrics():
         "csv_rechecked_lifetime": 0,
         "derived_addresses_today": 0,
         "altcoin_files_converted": 0,
-        "alerts_sent_today": {},
+        "alerts_sent_today": {c: 0 for c in ALERT_CHANNELS},
+        "alerts_sent_lifetime": {c: 0 for c in ALERT_CHANNELS},
         "addresses_checked_today": {
             "btc": 0, "doge": 0, "ltc": 0, "bch": 0, "rvn": 0, "pep": 0, "dash": 0, "eth": 0
         },

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -228,7 +228,7 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
         )
         set_thread_health("keygen", True)
 
-        shutdown_evt = get_shutdown_event()
+        shutdown_evt = get_shutdown_event("keygen")
         pause_evt = get_pause_event("keygen")
 
         batches_completed = 0

--- a/ui/dashboard_gui.py
+++ b/ui/dashboard_gui.py
@@ -480,8 +480,16 @@ class DashboardGUI:
                             title = name_map.get(mod, mod.replace('_', ' ').title())
                             lines.append(f"{title} → {name}")
                     elif key in ("matches_found_lifetime", "addresses_checked_lifetime", "addresses_checked_today", "csv_checker", "alerts_sent_today"):
-                        for coin, amt in value.items():
-                            lines.append(f"{coin.upper()}: {amt}")
+                        if key in ("matches_found_lifetime", "addresses_checked_lifetime", "addresses_checked_today"):
+                            today_dict = stats.get(key.replace("lifetime", "today"), {}) if "lifetime" in key else stats.get(key.replace("today", "lifetime"), {})
+                            lifetime_dict = stats.get(key.replace("today", "lifetime"), {}) if "today" in key else value
+                            for coin in lifetime_dict:
+                                t = today_dict.get(coin, 0)
+                                l = lifetime_dict.get(coin, 0)
+                                lines.append(f"{coin.upper()}: {t} / {l}")
+                        else:
+                            for coin, amt in value.items():
+                                lines.append(f"{coin.upper()}: {amt}")
                     else:
                         for gid, info in value.items():
                             name = info.get('name', '')


### PR DESCRIPTION
## Summary
- persist all alert counts and keys generated
- track per-coin metrics in a combined today/lifetime view
- handle per-module shutdown events for GUI controls
- allow CSV checker processes to stop on demand

## Testing
- `python -m py_compile core/dashboard.py core/alerts.py core/csv_checker.py core/keygen.py ui/dashboard_gui.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6886c5d459088327ade7cb32bf7061ca