### PR TITLE
Fix dashboard status handling

### DIFF
--- a/ui/dashboard_gui.py
+++ b/ui/dashboard_gui.py
@@ -416,7 +416,11 @@ class DashboardGUI:
         """Synchronize button states with current metrics on startup."""
         try:
             stats = get_current_metrics()
-            status_dict = stats.get("thread_health_flags", stats.get("status", {}))
+            status_dict = stats.get("thread_health_flags")
+            if not isinstance(status_dict, dict):
+                status_dict = stats.get("status", {})
+                if not isinstance(status_dict, dict):
+                    status_dict = {}
             key_map = {"vanity": "keygen"}
             for label, updater in self.module_buttons.items():
                 metric_key = key_map.get(label.lower(), label.lower())
@@ -439,7 +443,11 @@ class DashboardGUI:
                 if var.get() != live:
                     var.set(live)
             # Update module button states based on metrics
-            status_dict = stats.get("thread_health_flags", stats.get("status", {}))
+            status_dict = stats.get("thread_health_flags")
+            if not isinstance(status_dict, dict):
+                status_dict = stats.get("status", {})
+                if not isinstance(status_dict, dict):
+                    status_dict = {}
             key_map = {"vanity": "keygen"}
             for label, updater in self.module_buttons.items():
                 metric_key = key_map.get(label.lower(), label.lower())


### PR DESCRIPTION
## Summary
- handle cases where `thread_health_flags` isn't a dict in the dashboard

## Testing
- `python -m py_compile ui/dashboard_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6886f2061ba483279c6278267a142eb4