### PR TITLE
fix: harden GUI metric rendering + backend validation

### DIFF
--- a/ui/dashboard_gui.py
+++ b/ui/dashboard_gui.py
@@ -405,6 +405,8 @@ class DashboardGUI:
 
     def _format_coin_dict(self, data, per_row=2):
         """Return multiline string with coin values in aligned columns."""
+        if not isinstance(data, dict):
+            return str(data)
         items = list(data.items())
         lines = []
         for i in range(0, len(items), per_row):
@@ -521,18 +523,24 @@ class DashboardGUI:
                         "alerts_sent_today",
                         "alerts_sent_lifetime",
                     ):
-                        lines.extend(self._format_coin_dict(value).splitlines())
+                        if isinstance(value, dict):
+                            lines.extend(self._format_coin_dict(value).splitlines())
+                        else:
+                            lines.append(f"{key}: {value}")
                     else:
                         for gid, info in value.items():
-                            name = info.get('name', '')
-                            usage = info.get('usage', 'N/A')
-                            vram = info.get('vram', 'N/A')
-                            temp = info.get('temp', 'N/A')
-                            lines.append(f"{gid}: {name}")
-                            detail = f"  Usage: {usage}  VRAM: {vram}"
-                            if temp and temp != 'N/A':
-                                detail += f"  Temp: {temp}"
-                            lines.append(detail)
+                            if isinstance(info, dict):
+                                name = info.get('name', '')
+                                usage = info.get('usage', 'N/A')
+                                vram = info.get('vram', 'N/A')
+                                temp = info.get('temp', 'N/A')
+                                lines.append(f"{gid}: {name}")
+                                detail = f"  Usage: {usage}  VRAM: {vram}"
+                                if temp and temp != 'N/A':
+                                    detail += f"  Temp: {temp}"
+                                lines.append(detail)
+                            else:
+                                lines.append(f"{gid}: {info}")
                 else:
                     lines.append(str(value))
                 widget.config(state="normal")
@@ -540,21 +548,20 @@ class DashboardGUI:
                 widget.insert("end", "\n".join(lines) or "N/A")
                 widget.config(state="disabled")
             else:
-                if isinstance(value, dict):
-                    if key in (
-                        "addresses_generated_today",
-                        "addresses_generated_lifetime",
-                        "matches_found_today",
-                        "matches_found_lifetime",
-                        "addresses_checked_today",
-                        "addresses_checked_lifetime",
-                        "alerts_sent_today",
-                        "alerts_sent_lifetime",
-                    ):
-                        disp = self._format_coin_dict(value)
-                    else:
-                        lines = [f"{k.upper()}: {v}" for k, v in value.items()]
-                        disp = "\n".join(lines)
+                if key in (
+                    "addresses_generated_today",
+                    "addresses_generated_lifetime",
+                    "matches_found_today",
+                    "matches_found_lifetime",
+                    "addresses_checked_today",
+                    "addresses_checked_lifetime",
+                    "alerts_sent_today",
+                    "alerts_sent_lifetime",
+                ):
+                    disp = self._format_coin_dict(value) if isinstance(value, dict) else str(value)
+                elif isinstance(value, dict):
+                    lines = [f"{k.upper()}: {v}" for k, v in value.items()]
+                    disp = "\n".join(lines)
                 else:
                     disp = str(value)
                     if len(disp) > 40:


### PR DESCRIPTION
## Summary
- avoid crashes rendering lifetime metrics when corrupt values appear
- verify these critical metrics are always dicts in backend
- auto-heal lifetime metrics file if types are wrong

## Testing
- `python -m py_compile ui/dashboard_gui.py core/dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_688d0ad4ffec832789adc4d8bcef2c39