### PR TITLE
Add missing tzlocal dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ playsound
 GPUtil
 eth-account
 python-dotenv
+tzlocal


### PR DESCRIPTION
## Summary
- include `tzlocal` in requirements to support automatic timezone detection

## Testing
- `pip install tzlocal`
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'\nimport tzlocal\nprint('tzlocal zone', tzlocal.get_localzone())\nPY`


------
https://chatgpt.com/codex/tasks/task_e_688e4e646a148327b64d5ac36b903bdd