### PR TITLE
Fix metrics calculations and GUI layout

### DIFF
--- a/core/dashboard.py
+++ b/core/dashboard.py
@@ -127,7 +127,11 @@ def save_lifetime_metrics():
     data = {}
     for key in LIFETIME_KEYS:
         val = metrics.get(key)
-        if isinstance(val, dict):
+        try:
+            from multiprocessing.managers import DictProxy
+        except Exception:
+            DictProxy = dict  # fallback
+        if isinstance(val, DictProxy) or isinstance(val, dict):
             data[key] = dict(val)
         else:
             data[key] = val

--- a/ui/dashboard_gui.py
+++ b/ui/dashboard_gui.py
@@ -158,7 +158,7 @@ class DashboardGUI:
                     pb = ttk.Progressbar(frame, length=150, mode="determinate")
                     pb.grid(row=i, column=1, sticky="w", padx=2, pady=2)
                     self.metrics[key] = pb
-                elif key in ("gpu_stats", "gpu_assignments", "status", "matches_found_lifetime", "addresses_checked_lifetime", "addresses_checked_today", "csv_checker", "alerts_sent_today"):
+                elif key in ("gpu_stats", "gpu_assignments", "status", "csv_checker", "alerts_sent_today"):
                     txt = tk.Text(frame, height=8, width=45, wrap="none", font=FONT)
                     txt.grid(row=i, column=1, sticky="nsew", padx=2, pady=2)
                     txt.configure(state="disabled")


### PR DESCRIPTION
## Summary
- compute keys/sec from runtime key generation and track session start
- persist lifetime metrics safely and avoid DictProxy serialization issues
- streamline coin metric display to dynamic labels, removing large blank areas

## Testing
- `python -m py_compile core/dashboard.py core/keygen.py ui/dashboard_gui.py main.py`
- `python - <<'PY'
import time, json, os
import core.dashboard as d

d.init_dashboard_manager()
# Reset metrics
d.set_metric('keys_generated_today', 0)
d.set_metric('keys_generated_lifetime', 0)
d.save_lifetime_metrics()

start_time = time.time()
start_keys = d.get_metric('keys_generated_today', 0)
# simulate generating keys
for _ in range(3):
    d.increment_metric('keys_generated_today', 50)
    d.increment_metric('keys_generated_lifetime', 50)
    time.sleep(0.3)
elapsed = max(1, time.time() - start_time)
keys_per_sec = (d.get_metric('keys_generated_today', 0) - start_keys) / elapsed
print('Simulated keys/sec:', round(keys_per_sec, 2))

# Persist and read file
d.save_lifetime_metrics()
with open('metrics_lifetime.json') as f:
    data = json.load(f)
print('Lifetime total from file:', data.get('keys_generated_lifetime'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_688e62cddb3c832786e434f724adc708