### PR TITLE
Prevent alert matches from pausing modules

### DIFF
--- a/core/alerts.py
+++ b/core/alerts.py
@@ -203,7 +203,7 @@ def alert_match(match_data, test_mode=False):
             server.login(SMTP_USERNAME, SMTP_PASSWORD)
             server.send_message(msg)
             server.quit()
-            log_message("📧 Email alert sent.", "INFO")
+            log_message("[ALERT] ✉️ Email sent", "INFO")
             increment_metric("alerts_sent_today.email")
             increment_metric("alerts_sent_lifetime.email")
         except Exception as e:
@@ -215,7 +215,7 @@ def alert_match(match_data, test_mode=False):
             telegram_url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
             resp = requests.post(telegram_url, json={"chat_id": TELEGRAM_CHAT_ID, "text": match_text}, timeout=10)
             if resp.ok and resp.json().get("ok"):
-                log_message("📨 Telegram alert sent.", "INFO")
+                log_message("[ALERT] 📟 Telegram sent", "INFO")
                 increment_metric("alerts_sent_today.telegram")
                 increment_metric("alerts_sent_lifetime.telegram")
             else:

--- a/core/csv_checker.py
+++ b/core/csv_checker.py
@@ -233,7 +233,14 @@ def check_csv_against_addresses(csv_file, address_sets, recheck=False, safe_mode
                                             "row_number": rows_scanned
                                         }
 
-                                        log_message(f"✅ MATCH FOUND: {addr} ({coin}) | File: {filename} | Row: {rows_scanned}", "ALERT")
+                                        log_message(
+                                            f"[MATCH DETECTED] ✅ Match found for {coin.upper()} in row {rows_scanned} — alert triggered",
+                                            "DEBUG",
+                                        )
+                                        log_message(
+                                            f"✅ MATCH FOUND: {addr} ({coin}) | File: {filename} | Row: {rows_scanned}",
+                                            "ALERT",
+                                        )
 
                                         if ENABLE_PGP:
                                             try:
@@ -267,6 +274,7 @@ def check_csv_against_addresses(csv_file, address_sets, recheck=False, safe_mode
                                             update_dashboard_stat("matches_found_lifetime", get_metric("matches_found_lifetime"))
                                         row_matches.append(addr)
                                         all_matches.append(match_payload)
+                                        log_message("[STATUS] CSV Checker continuing without interruption", "DEBUG")
                                         # Continue scanning the row for additional matches
                                     except Exception as match_err:
                                         log_message(f"⚠️ Match processing error for {addr}: {match_err}", "WARN")

--- a/main.py
+++ b/main.py
@@ -375,10 +375,11 @@ def run_allinkeys(args):
         'csv_check': dashboard_core.manager.Event(),
         'csv_recheck': dashboard_core.manager.Event(),
     }
-    from core.dashboard import register_control_events
+    from core.dashboard import register_control_events, get_pause_event
     register_control_events(shutdown_event, None)  # global events
     for name, ev in pause_events.items():
         register_control_events(shutdown_events.get(name), ev, module=name)
+        pause_events[name] = get_pause_event(name)
     try:
         init_shared_metrics(shared_metrics)
         print("[debug] Shared metrics initialized for", __name__, flush=True)


### PR DESCRIPTION
## Summary
- Wrap module pause events to detect and warn about non-GUI state changes
- Ensure pause events passed to workers are the wrapped versions
- Add match and alert debug logs to confirm CSV checker continues running

## Testing
- `pytest -q`
- `python -m py_compile core/alerts.py core/csv_checker.py core/dashboard.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688e7dd39e448327a9c83b2a754bcd4a