### PR TITLE
Fix altcoin conversion KeyError by using shared-memory GPU flags

### DIFF
--- a/core/gpu_scheduler.py
+++ b/core/gpu_scheduler.py
@@ -158,17 +158,16 @@ def monitor_backlog_and_reassign(shared_metrics, vanity_flag, altcoin_flag, assi
         time.sleep(2)
 
 
-def start_scheduler(shared_metrics, shutdown_event, manager=None):
+def start_scheduler(shared_metrics, shutdown_event):
     """Helper to spawn the scheduler in its own process.
 
     Returns (process, vanity_flag, altcoin_flag, assignment_flag)
     """
-    if manager is None:
-        manager = multiprocessing.Manager()
-    vanity_flag = manager.Value("i", 1)
-    altcoin_flag = manager.Value("i", 1)
-    assignment_flag = manager.Value("i", 0)
-    proc = multiprocessing.Process(
+    ctx = multiprocessing.get_context("spawn")
+    vanity_flag = ctx.Value("i", 1)
+    altcoin_flag = ctx.Value("i", 1)
+    assignment_flag = ctx.Value("i", 0)
+    proc = ctx.Process(
         target=monitor_backlog_and_reassign,
         args=(shared_metrics, vanity_flag, altcoin_flag, assignment_flag, shutdown_event),
         name="GPUScheduler",

--- a/main.py
+++ b/main.py
@@ -258,7 +258,7 @@ def run_all_processes(args, shutdown_events, shared_metrics, pause_events, log_q
 
     from core.gpu_scheduler import start_scheduler
     gpu_sched, vanity_gpu_flag, altcoin_gpu_flag, assignment_flag = start_scheduler(
-        shared_metrics, shutdown_events.get('keygen'), dashboard_core.manager
+        shared_metrics, shutdown_events.get('keygen')
     )
     processes.append(gpu_sched)
     named_processes.append(("gpu_scheduler", gpu_sched))


### PR DESCRIPTION
## Summary
- replace Manager.Value with shared-memory multiprocessing.Value in GPU scheduler to avoid lost proxy KeyErrors
- update main to call new scheduler signature

## Testing
- `python -m py_compile core/gpu_scheduler.py main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ebe4ba7a48327b8e5538cc9663fce