### PR TITLE
Call spawn start method before multiprocessing imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,12 @@
 # main.py
 
+if __name__ == "__main__":
+    import multiprocessing
+    try:
+        multiprocessing.set_start_method("spawn")
+    except RuntimeError:
+        pass  # Already set
+
 import os
 import io
 import time
@@ -9,7 +16,7 @@ import argparse
 import multiprocessing
 import threading
 from datetime import datetime, timedelta
-from multiprocessing import Process, set_start_method
+from multiprocessing import Process
 import psutil
 
 # Wrap stdout once with UTF-8 encoding if not already wrapped
@@ -487,7 +494,6 @@ def run_allinkeys(args):
 
 
 if __name__ == "__main__":
-    set_start_method("spawn")
 
     if not os.path.exists(VANITYSEARCH_PATH):
         raise FileNotFoundError(f"VanitySearch not found at: {VANITYSEARCH_PATH}")


### PR DESCRIPTION
## Summary
- Set multiprocessing start method to "spawn" at the very top of `main.py` and guard against `RuntimeError` if already initialized.
- Remove late `set_start_method` call so entrypoint simply validates dependencies and launches the application.

## Testing
- `python -m py_compile main.py`
- `pytest`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_688f9ef53b0483278e30a3f3716f0385