### PR TITLE
Harden keygen IO and backlog pauses

### DIFF
--- a/core/utils/io_safety.py
+++ b/core/utils/io_safety.py
@@ -1,0 +1,51 @@
+import os
+import time
+from typing import Tuple, TextIO
+
+
+def atomic_open(path: str, mode: str = "w", encoding: str = "utf-8") -> Tuple[str, TextIO]:
+    """Open a temp file in the same directory as ``path`` for atomic writes.
+
+    Returns a tuple of (temp_path, handle). Caller should write to the handle
+    and then invoke :func:`atomic_commit` to move it into place.
+    """
+    dir_name = os.path.dirname(path)
+    base_name = os.path.basename(path)
+    tmp_name = f".{base_name}.tmp-{os.getpid()}-{int(time.time()*1000)}"
+    tmp_path = os.path.join(dir_name, tmp_name)
+    handle = open(tmp_path, mode, encoding=encoding)
+    return tmp_path, handle
+
+
+def atomic_commit(tmp_path: str, final_path: str) -> None:
+    """Flush ``tmp_path`` to disk and atomically replace ``final_path``.
+
+    The temporary file should be closed before calling this function.
+    """
+    fd = os.open(tmp_path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    os.replace(tmp_path, final_path)
+
+
+def safe_nonempty(path: str, min_bytes: int = 128) -> bool:
+    """Return True if ``path`` exists and is at least ``min_bytes`` bytes."""
+    try:
+        return os.path.getsize(path) >= min_bytes
+    except OSError:
+        return False
+
+
+def unique_path(base_path: str, suffix: str) -> str:
+    """Return a unique filename based on ``base_path`` and ``suffix``."""
+    candidate = f"{base_path}{suffix}"
+    if not os.path.exists(candidate):
+        return candidate
+    i = 1
+    while True:
+        candidate = f"{base_path}{suffix}.{i}"
+        if not os.path.exists(candidate):
+            return candidate
+        i += 1

--- a/ui/dashboard_gui.py
+++ b/ui/dashboard_gui.py
@@ -64,12 +64,25 @@ class DashboardGUI:
         self.refresh_loop()
 
     def create_widgets(self):
+        """Create all dashboard widgets using a deterministic row counter."""
+        row = 0
+
+        def _next_row():
+            nonlocal row
+            r = row
+            row += 1
+            return r
+
+        self.master.rowconfigure(0, weight=1)
+        self.master.columnconfigure(0, weight=1)
+        self.master.columnconfigure(1, weight=0)
+
         # ----- Scrollable container -----
         self.canvas = tk.Canvas(self.master, borderwidth=0)
         self.scrollbar = ttk.Scrollbar(self.master, orient="vertical", command=self.canvas.yview)
         self.canvas.configure(yscrollcommand=self.scrollbar.set)
-        self.scrollbar.pack(side="right", fill="y")
-        self.canvas.pack(side="left", fill="both", expand=True)
+        self.canvas.grid(row=0, column=0, sticky="nsew")
+        self.scrollbar.grid(row=0, column=1, sticky="ns")
         self.container = ttk.Frame(self.canvas)
         self.container_window = self.canvas.create_window((0, 0), window=self.container, anchor="nw")
         self.container.bind(
@@ -160,7 +173,7 @@ class DashboardGUI:
         column_frames["CSV Checker"].grid(row=0, column=1, sticky="nsew", padx=5)
         column_frames["Backlog"].grid(row=0, column=2, sticky="nsew", padx=5)
 
-        for group, keys in grouped_keys.items():
+        for col, (group, keys) in enumerate(grouped_keys.items()):
             if not keys:
                 continue
             parent = column_frames[group]
@@ -217,7 +230,7 @@ class DashboardGUI:
                 )
                 self.metrics["backlog_progress"] = {}
 
-            row += 1
+            row = _next_row()
 
             if group == "Backlog":
                 backlog_col = col


### PR DESCRIPTION
## Summary
- Fix dashboard row handling with responsive grid layout
- Add atomic IO helpers and prevent empty vanity files
- Skip empty vanity outputs in sorter and altcoin derive
- Throttle pause warnings and add backlog pause hysteresis

## Testing
- `python -m py_compile core/utils/io_safety.py core/vanity_runner.py core/btc_only_checker.py core/altcoin_derive.py core/dashboard.py ui/dashboard_gui.py main.py`
- `pytest`
- `python main.py -only btc -funded --skip-downloads` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689c30b8a4c0832782138d4eec859a87