### PR TITLE
Handle missing sorted vanity outputs

### DIFF
--- a/core/sorter.py
+++ b/core/sorter.py
@@ -1,0 +1,53 @@
+import os
+from typing import Optional
+from core.utils.io_safety import safe_nonempty
+
+PUBADDR_MARK = "PubAddr"
+
+def sort_if_ready(input_path: str, logger, min_bytes: int = 128) -> Optional[str]:
+    """
+    If input_path exists, is non-empty, and contains parsable addresses,
+    write a `.sorted` sibling with sorted/unique addresses.
+    Returns the sorted path on success, None on no-op / no addresses.
+    Never creates an empty .sorted.
+    """
+    if not safe_nonempty(input_path, min_bytes=min_bytes):
+        logger.info(f"Skipping extractor for empty/not-ready file {os.path.basename(input_path)}")
+        return None
+
+    sorted_path = input_path + ".sorted"
+    addrs = set()
+
+    try:
+        with open(input_path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                s = line.strip()
+                if not s:
+                    continue
+                if PUBADDR_MARK in s:
+                    # Legacy block format: extract final address token after marker
+                    # (Adjust this slice logic to your actual PubAddr line structure)
+                    parts = s.split()
+                    last = parts[-1]
+                    addrs.add(last.lower() if last.lower().startswith("bc1") else last)
+                else:
+                    # Raw-address-per-line mode
+                    if s[0] in ("1", "3") or s.lower().startswith("bc1"):
+                        addrs.add(s.lower() if s.lower().startswith("bc1") else s)
+    except FileNotFoundError:
+        return None
+
+    if not addrs:
+        # No addresses parsed → do not create a sidecar
+        return None
+
+    # Write deterministically sorted output
+    try:
+        with open(sorted_path, "w", encoding="utf-8") as out:
+            for a in sorted(addrs):
+                out.write(a + "\n")
+    except OSError as e:
+        logger.warning(f"⚠️ Failed writing sidecar for {os.path.basename(input_path)}: {e}")
+        return None
+
+    return sorted_path

--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -224,13 +224,6 @@ def run_vanitysearch(
         return False
 
     atomic_commit(tmp_path, output_path)
-    try:
-        from core.btc_only_checker import sort_addresses_in_file
-
-        sidecar = f"{output_path}.sorted"
-        sort_addresses_in_file(output_path, sidecar, logger)
-    except Exception:
-        logger.exception("Sorter failed for %s", output_path)
     return True
 
 

--- a/main.py
+++ b/main.py
@@ -469,7 +469,10 @@ def run_btc_only(args):
                         "backlog_resume",
                         f"Resumed keygen: backlog {backlog} ≤ {CHECKER_BACKLOG_PAUSE_THRESHOLD}",
                     )
-            process_pending_vanity_outputs_once(logger)
+            try:
+                process_pending_vanity_outputs_once(logger)
+            except Exception as e:
+                logger.warning(f"⚠️ btc_only processing tick encountered an error but will continue: {e}")
             time.sleep(2)
     except KeyboardInterrupt:
         log_message("Shutting down BTC-only mode", "INFO")


### PR DESCRIPTION
## Summary
- Skip BTC vanity outputs that are empty or too fresh
- Sort addresses on-demand and guard BTC-only loop against transient errors
- Add standalone sorter module and simplify vanity runner commit

## Testing
- ✅ `python -m py_compile core/btc_only_checker.py core/sorter.py core/vanity_runner.py main.py`
- ⚠️ `python main.py -only btc -funded --skip-downloads` (missing dependency: eth_account)


------
https://chatgpt.com/codex/tasks/task_e_689c4dd4cc5c832794e0d8823fe85d65