### PR TITLE
Unify VanitySearch command handling and logging

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -139,6 +139,8 @@ COIN_DOWNLOAD_URLS = {
 MAX_DAILY_FILES_PER_COIN = 2
 FILTER_ONLY_P2PKH = False
 
+# Address generation toggles
+ENABLE_P2PKH = True          # legacy "1" prefix (P2PKH)
 # SegWit address generation toggles
 ENABLE_P2WPKH = True         # bc1q… (Bech32 v0)
 ENABLE_TAPROOT = True        # bc1p… (Bech32m v1)

--- a/core/backlog.py
+++ b/core/backlog.py
@@ -80,7 +80,11 @@ def start_backlog_conversion_loop(shared_metrics=None, shutdown_event=None, paus
             if get_shutdown_event() and get_shutdown_event().is_set():
                 break
             try:
-                files = [f for f in os.listdir(VANITY_OUTPUT_DIR) if f.endswith(".txt")]
+                files = [
+                    f
+                    for f in os.listdir(VANITY_OUTPUT_DIR)
+                    if f.endswith(".txt") and not f.endswith(".part")
+                ]  # Do not process .part files
                 update_dashboard_stat("backlog_files_queued", len(files))
                 futures = []
                 for file in files:

--- a/ui/dashboard_gui.py
+++ b/ui/dashboard_gui.py
@@ -36,6 +36,7 @@ from config.settings import (
     DELETE_CSV_CHECKING_LOGS,
     OPEN_CONFIG_FILE_FROM_DASHBOARD,
     GPU_STRATEGY,
+    ENABLE_P2PKH,
     ENABLE_P2WPKH,
     ENABLE_TAPROOT,
 )
@@ -109,12 +110,28 @@ class DashboardGUI:
         addr_frame.pack(fill="x", padx=10, pady=5)
         addr_frame.grid_columnconfigure(0, weight=1)
         addr_frame.grid_columnconfigure(1, weight=1)
+        addr_frame.grid_columnconfigure(2, weight=1)
+        self.p2pkh_var = tk.BooleanVar(value=ENABLE_P2PKH)
         self.p2wpkh_var = tk.BooleanVar(value=ENABLE_P2WPKH)
         self.taproot_var = tk.BooleanVar(value=ENABLE_TAPROOT)
-        ttk.Checkbutton(addr_frame, text="bc1q (P2WPKH)", variable=self.p2wpkh_var,
-                        command=lambda: setattr(settings, 'ENABLE_P2WPKH', self.p2wpkh_var.get())).grid(row=0, column=0, sticky="w")
-        ttk.Checkbutton(addr_frame, text="bc1p (Taproot)", variable=self.taproot_var,
-                        command=lambda: setattr(settings, 'ENABLE_TAPROOT', self.taproot_var.get())).grid(row=0, column=1, sticky="w")
+        ttk.Checkbutton(
+            addr_frame,
+            text="1 (P2PKH)",
+            variable=self.p2pkh_var,
+            command=lambda: setattr(settings, 'ENABLE_P2PKH', self.p2pkh_var.get()),
+        ).grid(row=0, column=0, sticky="w")
+        ttk.Checkbutton(
+            addr_frame,
+            text="bc1q (P2WPKH)",
+            variable=self.p2wpkh_var,
+            command=lambda: setattr(settings, 'ENABLE_P2WPKH', self.p2wpkh_var.get()),
+        ).grid(row=0, column=1, sticky="w")
+        ttk.Checkbutton(
+            addr_frame,
+            text="bc1p (Taproot)",
+            variable=self.taproot_var,
+            command=lambda: setattr(settings, 'ENABLE_TAPROOT', self.taproot_var.get()),
+        ).grid(row=0, column=2, sticky="w")
 
         # Metric Panels
         self.section_frame = ttk.Frame(self.container)


### PR DESCRIPTION
## Summary
- expose ENABLE_P2PKH toggle and surface in dashboard checkbox
- centralize VanitySearch command builder with legacy/bc1 support and robust runner
- eliminate marker files in CSV checker and ignore `.part` backlog files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py -only btc -funded --skip-downloads` *(fails: ModuleNotFoundError: No module named 'eth_account')*


------
https://chatgpt.com/codex/tasks/task_e_689d3e9af778832799ae29d6fa3a9258