### PR TITLE
Fix VanitySearch output and metrics safety

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -27,7 +27,9 @@ FULL_DIR = os.path.join(DOWNLOADS_DIR, "full")
 UNIQUE_DIR = os.path.join(DOWNLOADS_DIR, "unique")
 # Where matches and encrypted alerts are archived
 MATCHES_DIR = os.path.join(BASE_DIR, "matches")
-VANITY_OUTPUT_DIR = os.path.join(BASE_DIR, "vanity_output")
+# VanitySearch text outputs
+VANITY_TXT_DIR = os.path.join(BASE_DIR, "output", "vanity_txt")
+VANITY_OUTPUT_DIR = VANITY_TXT_DIR  # legacy alias
 # Local audio clips for alerts
 SOUND_CLIPS_DIR = os.path.join(BASE_DIR, "alerts", "sounds")
 CHECKPOINT_PATH = os.path.join(LOG_DIR, "restore_checkpoint.json")
@@ -59,8 +61,10 @@ VANITY_PATTERN = "1**"  # Change this pattern to match your target (e.g., starts
 VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", "vanitysearch.exe")  # Adjust if renamed
 MAX_KEYS_PER_FILE = 100_000  #Deprecated
 # Output file rotation config (for VanitySearch stream)
-MAX_OUTPUT_FILE_SIZE = 250 * 1024 * 1024  # 250 MB default
-MAX_OUTPUT_LINES = 200_000              # 200,000 lines per file
+VANITY_ROTATE_LINES = 200_000
+VANITY_MAX_BYTES = 500 * 1024 * 1024
+MAX_OUTPUT_LINES = VANITY_ROTATE_LINES  # legacy alias
+MAX_OUTPUT_FILE_SIZE = VANITY_MAX_BYTES  # legacy alias
 USE_GPU = True
 ROTATE_INTERVAL_SECONDS = 60
 
@@ -141,12 +145,11 @@ FILTER_ONLY_P2PKH = False
 
 # Address generation toggles
 ENABLE_P2PKH = True          # legacy "1" prefix (P2PKH)
-# SegWit address generation toggles
-# Disabled by default for backwards compatibility.  Users can enable
-# bech32 modes via settings or ``--enable-bc1`` CLI flag.
-ENABLE_BECH32_DEFAULT = False
-ENABLE_P2WPKH = ENABLE_BECH32_DEFAULT         # bc1q… (Bech32 v0)
-ENABLE_TAPROOT = ENABLE_BECH32_DEFAULT        # bc1p… (Bech32m v1)
+# SegWit address generation toggles (bc1)
+ENABLE_BC1_DEFAULT = False
+ENABLE_BECH32_DEFAULT = ENABLE_BC1_DEFAULT  # deprecated alias
+ENABLE_P2WPKH = ENABLE_BC1_DEFAULT         # bc1q… (Bech32 v0)
+ENABLE_TAPROOT = ENABLE_BC1_DEFAULT        # bc1p… (Bech32m v1)
 
 # GUI default patterns used when “All” selected
 DEFAULT_BTC_PATTERNS = ["1**"]                # legacy
@@ -645,9 +648,9 @@ BUTTONS_ENABLED = {
 # ===================== 🖥️ GPU/CPU BACKENDS ==========================
 # GPU/CPU selection & binaries
 GPU_BACKEND = "auto"        # "cuda" | "opencl" | "auto"
-VANITYSEARCH_BIN_CUDA = r"P:\\ALLINKEYS\\bin\\VanitySearch_cuda.exe"
-VANITYSEARCH_BIN_OPENCL = r"P:\\ALLINKEYS\\bin\\VanitySearch_opencl.exe"
-VANITYSEARCH_BIN_CPU = r"P:\\ALLINKEYS\\bin\\VanitySearch_cpu.exe"  # fallback only
+VANITYSEARCH_BIN_CUDA = os.path.join(BASE_DIR, "bin", "vanitysearch_cuda.exe")
+VANITYSEARCH_BIN_OPENCL = os.path.join(BASE_DIR, "bin", "vanitysearch_opencl.exe")
+VANITYSEARCH_BIN_CPU = VANITYSEARCH_PATH  # fallback only
 
 FORCE_CPU_FALLBACK = False  # If True, run CPU even if GPU available
 MIN_EXPECTED_GPU_MKEYS = 120.0  # GTX 1060 typical: 150–230 MKeys/s

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -166,8 +166,7 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
     except Exception as e:
         logger.exception(f"ensure_metrics_ready failed in {__name__}: {e}")
     register_control_events(shutdown_event, pause_event, module="keygen")
-    if not os.path.exists(VANITY_OUTPUT_DIR):
-        os.makedirs(VANITY_OUTPUT_DIR)
+    os.makedirs(VANITY_OUTPUT_DIR, exist_ok=True)
 
     checkpoint = load_checkpoint()
     if checkpoint:

--- a/core/vanity_io.py
+++ b/core/vanity_io.py
@@ -1,0 +1,60 @@
+import os
+
+class RollingAtomicWriter:
+    """Write lines to a temporary file then atomically rename on rotation.
+
+    Parameters
+    ----------
+    path : str
+        Destination file path when rotation occurs.
+    max_lines : int
+        Maximum number of lines to write before rotating.
+    max_bytes : int
+        Maximum number of bytes to write before rotating.
+    """
+
+    def __init__(self, path: str, max_lines: int, max_bytes: int) -> None:
+        self.final_path = path
+        self.temp_path = path + ".part"
+        self.max_lines = max_lines
+        self.max_bytes = max_bytes
+        self.lines = 0
+        self.bytes = 0
+        self._closed = False
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        self._fh = open(self.temp_path, "w", encoding="utf-8")
+
+    def write(self, line: str) -> bool:
+        """Write ``line`` to the file and return True if rotation occurred."""
+        if self._closed:
+            return True
+        self._fh.write(line)
+        self.lines += 1
+        self.bytes += len(line.encode("utf-8"))
+        if self.lines >= self.max_lines or self.bytes >= self.max_bytes:
+            self.rotate()
+            return True
+        return False
+
+    def rotate(self) -> None:
+        if self._closed:
+            return
+        self._fh.flush()
+        os.fsync(self._fh.fileno())
+        self._fh.close()
+        os.replace(self.temp_path, self.final_path)
+        self._closed = True
+
+    def abort(self) -> None:
+        if self._closed:
+            return
+        try:
+            self._fh.close()
+        finally:
+            if os.path.exists(self.temp_path):
+                os.remove(self.temp_path)
+        self._closed = True
+
+    def close(self) -> None:
+        if not self._closed:
+            self.rotate()


### PR DESCRIPTION
## Summary
- add RollingAtomicWriter for atomic, rotating vanity outputs
- safely initialize worker metrics and avoid direct set_metric calls
- resolve vanitysearch.exe or vanitysearch_cuda.exe and capture stdout with GPU→OpenCL→CPU fallback

## Testing
- `python -m py_compile core/vanity_io.py core/vanity_runner.py core/keygen.py config/settings.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc429b31083279b8f78ab1cb09cac