### PR TITLE
Fix VanitySearch runner and restore canonical binary

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -59,6 +59,7 @@ BTC_MIN_FILE_AGE_SEC = 2.0            # ignore files newer than this
 # --- VanitySearch Settings ---
 VANITY_PATTERN = "1**"  # Change this pattern to match your target (e.g., starts with 1)
 VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", "vanitysearch.exe")  # Adjust if renamed
+VANITYSEARCH_EXE_NAME = "vanitysearch.exe"
 MAX_KEYS_PER_FILE = 100_000  #Deprecated
 # Output file rotation config (for VanitySearch stream)
 VANITY_ROTATE_LINES = 200_000

--- a/core/vanity_io.py
+++ b/core/vanity_io.py
@@ -1,60 +1,87 @@
 import os
+import time
+from typing import Optional, TextIO
+
+
+def ensure_dir(path: str) -> str:
+    """Create ``path`` if missing and return it."""
+    os.makedirs(path, exist_ok=True)
+    return path
+
 
 class RollingAtomicWriter:
-    """Write lines to a temporary file then atomically rename on rotation.
+    """Write lines to rolling files using atomic commit on rotation."""
 
-    Parameters
-    ----------
-    path : str
-        Destination file path when rotation occurs.
-    max_lines : int
-        Maximum number of lines to write before rotating.
-    max_bytes : int
-        Maximum number of bytes to write before rotating.
-    """
-
-    def __init__(self, path: str, max_lines: int, max_bytes: int) -> None:
-        self.final_path = path
-        self.temp_path = path + ".part"
-        self.max_lines = max_lines
+    def __init__(
+        self,
+        directory: str,
+        rotate_lines: int,
+        max_bytes: int,
+        prefix: str = "vanity",
+    ) -> None:
+        self.directory = ensure_dir(directory)
+        self.rotate_lines = rotate_lines
         self.max_bytes = max_bytes
-        self.lines = 0
-        self.bytes = 0
-        self._closed = False
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        self.prefix = prefix
+        self._counter = 0
+        self._fh: Optional[TextIO] = None
+        self._lines = 0
+        self._bytes = 0
+        self._open_new_file()
+
+    # Internal helpers -------------------------------------------------
+    def _next_filename(self) -> str:
+        self._counter += 1
+        ts = time.strftime("%Y%m%d_%H%M%S")
+        name = f"{self.prefix}_{ts}_{self._counter:03d}.txt"
+        return os.path.join(self.directory, name)
+
+    def _open_new_file(self) -> None:
+        self.final_path = self._next_filename()
+        self.temp_path = self.final_path + ".part"
         self._fh = open(self.temp_path, "w", encoding="utf-8")
+        self._lines = 0
+        self._bytes = 0
 
-    def write(self, line: str) -> bool:
-        """Write ``line`` to the file and return True if rotation occurred."""
-        if self._closed:
-            return True
-        self._fh.write(line)
-        self.lines += 1
-        self.bytes += len(line.encode("utf-8"))
-        if self.lines >= self.max_lines or self.bytes >= self.max_bytes:
-            self.rotate()
-            return True
-        return False
-
-    def rotate(self) -> None:
-        if self._closed:
+    def _commit(self) -> None:
+        if not self._fh:
             return
         self._fh.flush()
         os.fsync(self._fh.fileno())
         self._fh.close()
         os.replace(self.temp_path, self.final_path)
-        self._closed = True
+        self._fh = None
 
-    def abort(self) -> None:
-        if self._closed:
-            return
-        try:
-            self._fh.close()
-        finally:
-            if os.path.exists(self.temp_path):
-                os.remove(self.temp_path)
-        self._closed = True
+    # Public API -------------------------------------------------------
+    def write(self, text: str) -> bool:
+        """Legacy write that accepts a full line (with newline)."""
+        if not self._fh:
+            return False
+        self._fh.write(text)
+        self._lines += 1
+        self._bytes += len(text.encode("utf-8"))
+        rotated = self._lines >= self.rotate_lines or self._bytes >= self.max_bytes
+        if rotated:
+            self._commit()
+            self._open_new_file()
+        return rotated
+
+    def write_line(self, line: str) -> None:
+        """Write a single line (newline appended)."""
+        self.write(line + "\n")
 
     def close(self) -> None:
-        if not self._closed:
-            self.rotate()
+        """Finalize the current file if open."""
+        if self._fh:
+            self._commit()
+
+    def abort(self) -> None:
+        """Abort the current file and remove the temp file."""
+        if self._fh:
+            try:
+                self._fh.close()
+            finally:
+                if os.path.exists(self.temp_path):
+                    os.remove(self.temp_path)
+            self._fh = None
+

--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -1,392 +1,112 @@
-import os
-import re
-import subprocess
-import time
-import json
-import shutil
-from typing import Dict, List, Tuple, Optional
+import os, shutil, subprocess, time
+from typing import List, Optional
 
 from config.settings import (
-    GPU_BACKEND,
-    FORCE_CPU_FALLBACK,
-    USE_CPU_FALLBACK,
-    MIN_EXPECTED_GPU_MKEYS,
-    ENABLE_P2PKH,
-    ENABLE_P2WPKH,
-    ENABLE_TAPROOT,
-    DEFAULT_BTC_PATTERNS,
-    DEFAULT_BTC_PATTERNS_BECH32,
-    DEFAULT_BTC_PATTERNS_BECH32M,
-    VANITY_ROTATE_LINES,
-    VANITY_MAX_BYTES,
-    BASE_DIR,
+    VANITY_TXT_DIR, VANITY_ROTATE_LINES, VANITY_MAX_BYTES, ENABLE_BC1_DEFAULT
 )
-from core.logger import get_logger
-from core.dashboard import update_dashboard_stat
-from core.vanity_io import RollingAtomicWriter
-
-logger = get_logger(__name__)
-logger.info("Streaming vanity output via .part files → atomic rename enabled")
-
-# Optional Windows file locking to keep .part files visible and protected
-try:  # pragma: no cover - only effective on Windows
-    import msvcrt
-
-    def _lock_file(handle):
-        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
-
-    def _unlock_file(handle):
-        try:
-            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
-        except OSError:
-            pass
-except Exception:  # pragma: no cover - platform without msvcrt
-    def _lock_file(handle):
-        return None
-
-    def _unlock_file(handle):
-        return None
-
-# throttle warning frequency
-_LAST_WARN: Dict[str, float] = {}
+from core.vanity_io import RollingAtomicWriter, ensure_dir
+from core.dashboard import log_message
 
 
-def _warn_once(name: str, msg: str, interval: float = 30.0) -> None:
-    """Emit ``msg`` at most once per ``interval`` seconds for the given ``name``."""
-    now = time.time()
-    if now - _LAST_WARN.get(name, 0) >= interval:
-        logger.warning(msg)
-        _LAST_WARN[name] = now
+def _bin_dir() -> str:
+    return os.path.join(os.path.dirname(os.path.dirname(__file__)), "bin")
 
 
-def _run_binary(binary: str, args: List[str]) -> str:
-    try:
-        return subprocess.check_output([binary] + args, stderr=subprocess.STDOUT, text=True)
-    except Exception as exc:
-        logger.debug(f"Device probe failed for {binary}: {exc}")
-        return ""
+def _which(path: str) -> Optional[str]:
+    if os.path.isabs(path) and os.path.isfile(path):
+        return path
+    found = shutil.which(path)
+    return found if found else (path if os.path.isfile(path) else None)
 
 
-def probe_vanity_capabilities(vanity_path: str) -> dict:
-    """Run a quick capability check for VanitySearch to discover GPU usability.
-
-    Returns a dictionary with keys:
-        {
-          "binary_found": bool,
-          "gpu_supported": bool,
-          "gpu_vendor": "nvidia" | "amd" | None,
-          "version": str | None,
-          "raw_banner": str,
-        }
-    Strategy: invoke the binary with ``--help`` and parse banner lines for
-    CUDA/OpenCL hints.  Non-zero exit codes are treated as failure and the
-    full output is logged for troubleshooting.
-    """
-    info = {
-        "binary_found": False,
-        "gpu_supported": False,
-        "gpu_vendor": None,
-        "version": None,
-        "raw_banner": "",
-    }
-    if not vanity_path or not os.path.exists(vanity_path):
-        return info
-    info["binary_found"] = True
-    try:
-        proc = subprocess.run([vanity_path, "--help"], capture_output=True, text=True)
-        info["raw_banner"] = (proc.stdout or "") + (proc.stderr or "")
-        for line in info["raw_banner"].splitlines():
-            m = re.search(r"VanitySearch\s*v?([0-9.]+)", line, re.I)
-            if m:
-                info["version"] = m.group(1)
-            if "CUDA" in line.upper():
-                info["gpu_supported"] = True
-                info["gpu_vendor"] = "nvidia"
-            if "OPENCL" in line.upper():
-                info["gpu_supported"] = True
-                if info["gpu_vendor"] is None:
-                    info["gpu_vendor"] = "amd"
-        if proc.returncode != 0:
-            logger.error(
-                f"Capability probe failed for {vanity_path} (exit {proc.returncode})\n{info['raw_banner']}"
-            )
-            info["gpu_supported"] = False
-    except Exception as exc:  # pragma: no cover - unexpected failures
-        logger.error(f"Capability probe failed for {vanity_path}: {exc}", exc_info=True)
-    return info
+def _resolve_vanity_binaries() -> dict:
+    bin_dir = _bin_dir()
+    candidates = [
+        os.path.join(bin_dir, "vanitysearch.exe"),
+        os.path.join(bin_dir, "vanitysearch_cuda.exe"),
+        "vanitysearch.exe",
+        "vanitysearch_cuda.exe",
+    ]
+    exe = next((p for p in candidates if _which(p)), None)
+    return {"GPU": exe, "OPENCL": exe, "CPU": exe} if exe else {"GPU": None, "OPENCL": None, "CPU": None}
 
 
-def list_devices() -> Dict[str, List[Tuple[int, str]]]:
-    """Return available GPU devices for CUDA and OpenCL binaries."""
-    devices: Dict[str, List[Tuple[int, str]]] = {}
-    binaries = {
-        "cuda": VANITYSEARCH_BIN_CUDA,
-        "opencl": VANITYSEARCH_BIN_OPENCL,
-    }
-    for backend, bin_path in binaries.items():
-        if not os.path.exists(bin_path):
-            continue
-        out = _run_binary(bin_path, ["-l"])
-        entries: List[Tuple[int, str]] = []
-        for line in out.splitlines():
-            m = re.search(r"#(\d+)\s+(.+)$", line)
-            if m:
-                entries.append((int(m.group(1)), m.group(2).strip()))
-        if entries:
-            devices[backend] = entries
-    return devices
+def _build_patterns(patterns: Optional[List[str]]) -> List[str]:
+    pat_args: List[str] = []
+    if patterns:
+        for p in patterns:
+            if p and isinstance(p, str):
+                if p.lower().startswith("bc1") and not ENABLE_BC1_DEFAULT:
+                    continue
+                pat_args.extend(["-b", p])
+    return pat_args or ["-b", "1**"]
 
 
-_SELECTED_BACKEND: str = "cpu"
-_SELECTED_DEVICE_ID: Optional[int] = None
-_SELECTED_DEVICE_NAME: str = "CPU"
-_SELECTED_BINARY: str = VANITYSEARCH_BIN_CPU
-
-
-def resolve_vanitysearch_binary(backend: str) -> str:
-    """Resolve VanitySearch executable path for the requested ``backend``."""
-    bin_dir = os.path.join(BASE_DIR, "bin")
-    names = []
-    if backend == "cuda":
-        names = ["vanitysearch_cuda.exe", "vanitysearch.exe"]
-    elif backend == "opencl":
-        names = ["vanitysearch_opencl.exe", "vanitysearch.exe"]
-    else:
-        names = ["vanitysearch.exe"]
-    for n in names:
-        candidate = os.path.join(bin_dir, n)
-        if os.path.exists(candidate):
-            return candidate
-    for n in names:
-        found = shutil.which(n)
-        if found:
-            return found
-    # Fallback to first candidate in bin_dir
-    return os.path.join(bin_dir, names[0])
-
-
-def probe_device() -> Tuple[str, Optional[int], str, str]:
-    """Select appropriate backend/device based on settings and availability."""
-    global _SELECTED_BACKEND, _SELECTED_DEVICE_ID, _SELECTED_DEVICE_NAME, _SELECTED_BINARY
-
-    devices = list_devices()
-    backend = "cpu"
-    device_id: Optional[int] = None
-    device_name = "CPU"
-
-    if not FORCE_CPU_FALLBACK:
-        if GPU_BACKEND in ("cuda", "opencl") and devices.get(GPU_BACKEND):
-            backend = GPU_BACKEND
-            device_id, device_name = devices[GPU_BACKEND][0]
-        elif GPU_BACKEND == "auto":
-            for cand in ("cuda", "opencl"):
-                if devices.get(cand):
-                    backend = cand
-                    device_id, device_name = devices[cand][0]
-                    break
-
-    binary = resolve_vanitysearch_binary(backend)
-    if backend in ("cuda", "opencl") and not os.path.exists(binary):
-        _warn_once("binary_missing", f"GPU backend {backend} selected but binary missing. Falling back to CPU")
-        backend = "cpu"
-        device_id = None
-        device_name = "CPU"
-        binary = resolve_vanitysearch_binary("cpu")
-
-    if backend != "cpu" and FORCE_CPU_FALLBACK:
-        _warn_once("cpu_forced", "GPU available but FORCE_CPU_FALLBACK=True; using CPU")
-        backend = "cpu"
-        device_id = None
-        device_name = "CPU"
-        binary = resolve_vanitysearch_binary("cpu")
-
-    capabilities = probe_vanity_capabilities(binary)
-    if backend != "cpu" and not capabilities.get("gpu_supported"):
-        msg = "GPU not available or unsupported by vanitysearch binary"
-        if USE_CPU_FALLBACK:
-            logger.error(f"{msg} → switched to CPU; set USE_CPU_FALLBACK=False to disallow")
-            backend = "cpu"
-            device_id = None
-            device_name = "CPU"
-            binary = resolve_vanitysearch_binary("cpu")
-        else:
-            logger.error(f"{msg}; aborting vanity worker")
-            update_dashboard_stat("vanitysearch_backend", "unavailable")
-            raise RuntimeError(msg)
-
-    if backend == "cpu" and GPU_BACKEND != "cpu":
-        _warn_once("cpu_fallback", "GPU backend requested but CPU binary selected")
-
-    _SELECTED_BACKEND = backend
-    _SELECTED_DEVICE_ID = device_id
-    _SELECTED_DEVICE_NAME = device_name
-    _SELECTED_BINARY = binary
-
-    update_dashboard_stat({
-        "vanitysearch_backend": backend,
-        "vanitysearch_device_name": device_name,
-    })
-    logger.info(
-        f"VanitySearch device: {device_name} | backend: {backend} | binary: {binary} | FORCE_CPU_FALLBACK={FORCE_CPU_FALLBACK}"
+def _popen_stream(args: List[str]) -> subprocess.Popen:
+    return subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+        universal_newlines=True,
+        encoding="utf-8",
+        errors="replace",
     )
-    return backend, device_id, device_name, binary
 
 
-def build_vanitysearch_args(hex_seed: str) -> List[Tuple[List[str], str]]:
-    """Compose VanitySearch argument lists for each requested address family.
-
-    The binary's ``--help`` output is parsed at runtime to determine the
-    correct switches for legacy P2PKH, Bech32 (v0) and Bech32m (v1) so newer
-    builds do not break when flags change.  This ensures ``bc1`` support does
-    not disable classic ``1…`` generation.
-    """
-
-    binary = _SELECTED_BINARY or resolve_vanitysearch_binary(_SELECTED_BACKEND)
-    help_text = _run_binary(binary, ["--help"])
-
-    switches = {"p2pkh": "-1", "bech32": "-b", "bech32m": "-3"}
-    for line in help_text.splitlines():
-        line_l = line.lower()
-        m = re.search(r"-(\S+)", line)
-        flag = f"-{m.group(1)}" if m else None
-        if "p2pkh" in line_l or "legacy" in line_l:
-            switches["p2pkh"] = flag or switches["p2pkh"]
-        if "bech32m" in line_l or "taproot" in line_l:
-            switches["bech32m"] = flag or switches["bech32m"]
-        elif "bech32" in line_l:
-            switches["bech32"] = flag or switches["bech32"]
-
-    jobs: List[Tuple[List[str], str]] = []
-    base = ["-s", hex_seed]
-
-    # Legacy P2PKH addresses are included unless explicitly disabled via
-    # ``ENABLE_P2PKH``.  This prevents accidental suppression when bc1 modes
-    # are enabled.
-    if ENABLE_P2PKH:
-        jobs.append((base + [switches["p2pkh"], DEFAULT_BTC_PATTERNS[0]], "p2pkh"))
-    if ENABLE_P2WPKH:
-        jobs.append((base + [switches["bech32"], DEFAULT_BTC_PATTERNS_BECH32[0]], "p2wpkh"))
-    if ENABLE_TAPROOT:
-        jobs.append((base + [switches["bech32m"], DEFAULT_BTC_PATTERNS_BECH32M[0]], "taproot"))
-    return jobs
-
-
-def run_vanitysearch(
-    seed_args: List[str],
-    output_path: str,
-    device_id: Optional[int],
-    backend: str,
-    timeout: int = 60,
-    pause_event=None,
-    addr_mode: str = "p2pkh",
-) -> bool:
-    """Execute VanitySearch streaming stdout to ``output_path`` using a safe writer."""
-    if pause_event and pause_event.is_set():
-        logger.info("Keygen paused; skipping VanitySearch job")
-        return False
-
-    enable_bc1 = ENABLE_P2WPKH or ENABLE_TAPROOT
-
-    def _run_once(b: str) -> bool:
-        binary = resolve_vanitysearch_binary(b)
-        cmd = [binary] + seed_args
-        if b in ("cuda", "opencl") and device_id is not None:
-            cmd += ["-gpu", str(device_id)]
-        mode_name = {"cuda": "GPU-CUDA", "opencl": "GPU-OpenCL/AMD", "cpu": "CPU"}.get(b, b)
-
-        sanitized: List[str] = []
-        skip = False
-        for c in cmd:
-            if skip:
-                skip = False
-                continue
-            if c == "-s":
-                sanitized.extend(["-s", "<seed>"])
-                skip = True
-            else:
-                sanitized.append(c)
-        logger.info(f"Executing VanitySearch ({mode_name}): {' '.join(sanitized)}")
-        update_dashboard_stat("vanitysearch_addr_mode", addr_mode)
-
-        writer = RollingAtomicWriter(output_path, VANITY_ROTATE_LINES, VANITY_MAX_BYTES)
-        addr_re = re.compile(
-            r"^(?:PubAddr|PubAddress)\s*:\s*(\S+)|"
-            r"^(1[1-9A-HJ-NP-Za-km-z]{25,34}|3[1-9A-HJ-NP-Za-km-z]{25,34}|bc1[0-9ac-hj-np-z]{11,71})$",
-            re.IGNORECASE,
-        )
-        valid_lines = 0
+def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) -> int:
+    out_dir = ensure_dir(VANITY_TXT_DIR)
+    bins = _resolve_vanity_binaries()
+    if not any(bins.values()):
+        log_message("❌ VanitySearch binary not found (expected vanitysearch.exe).", "ERROR")
+        return 0
+    pat_args = _build_patterns(patterns)
+    base = ["-s", str(seed_start), "-q"] + pat_args
+    modes = [("GPU", ["-gpu"]), ("OPENCL", ["-opencl"]), ("CPU", ["-cpu"])]
+    writer = RollingAtomicWriter(out_dir, rotate_lines=VANITY_ROTATE_LINES,
+                                 max_bytes=VANITY_MAX_BYTES, prefix="vanity")
+    total_lines = 0
+    for mode_name, mode_flag in modes:
+        exe = bins.get(mode_name)
+        if not exe:
+            continue
+        args = [exe] + base + mode_flag
         try:
-            proc = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
-            )
-            start = time.time()
-            for line in proc.stdout:
-                m = re.search(r"([0-9.]+)\s*([MK])?Key/s", line, re.IGNORECASE)
-                if m:
-                    speed = float(m.group(1))
-                    if m.group(2) and m.group(2).upper() == "K":
-                        speed /= 1000.0
-                    update_dashboard_stat("vanitysearch_current_mkeys", round(speed, 2))
-                    if b != "cpu" and speed < MIN_EXPECTED_GPU_MKEYS:
-                        _warn_once("low_speed", "Speed suggests CPU; check GPU selection")
-
-                stripped = line.strip()
-                if addr_re.match(stripped):
-                    addr = stripped.split()[0]
-                    if addr.lower().startswith("bc1") and not enable_bc1:
-                        continue
-                    valid_lines += 1
-                    if writer.write(line):
-                        proc.terminate()
-                elif valid_lines > 0:
-                    if writer.write(line):
-                        proc.terminate()
-
-                if pause_event and pause_event.is_set():
-                    proc.terminate()
-                if timeout and time.time() - start > timeout:
-                    proc.terminate()
-            proc.wait()
-            rc = proc.returncode
-        except Exception:
-            logger.exception("Failed to execute VanitySearch")
-            writer.abort()
-            return False
-        if rc != 0 or valid_lines == 0:
-            writer.abort()
-            if rc != 0:
-                logger.error(f"VanitySearch exited with code {rc}")
-            else:
-                logger.info(f"No address lines emitted by VanitySearch for {addr_mode}")
-            return False
+            log_message(f"🧪 Trying VanitySearch ({mode_name}): {' '.join(args)}", "INFO")
+            proc = _popen_stream(args)
+            last_ts = time.time()
+            while True:
+                if stop_event and stop_event.is_set():
+                    proc.terminate(); break
+                line = proc.stdout.readline()
+                if not line:
+                    if proc.poll() is not None:
+                        break
+                    if time.time() - last_ts > 5:
+                        log_message("⏳ VanitySearch running (no output yet)...", "DEBUG")
+                        last_ts = time.time()
+                    time.sleep(0.05)
+                    continue
+                last_ts = time.time()
+                if ("1" in line) or ("3" in line) or ("bc1" in line):
+                    writer.write_line(line.rstrip("\n"))
+                    total_lines += 1
+            rc = proc.wait(timeout=10)
+            if rc == 0 and total_lines > 0:
+                log_message(f"✅ VanitySearch finished ({mode_name}) with {total_lines} lines.", "SUCCESS")
+                writer.close(); return total_lines
+            log_message(f"⚠️ VanitySearch exited rc={rc}, lines={total_lines}. Trying next mode...", "WARNING")
+        except Exception as e:
+            log_message(f"⚠️ VanitySearch {mode_name} mode failed: {e}", "WARNING")
+            continue
+    if total_lines > 0:
         writer.close()
-        logger.info(
-            json.dumps(
-                {
-                    "event": "vanity_output_rotated",
-                    "file": os.path.basename(output_path),
-                    "lines": valid_lines,
-                }
-            )
-        )
-        return True
+        log_message(f"✅ Finalized partial output with {total_lines} lines after fallbacks.", "INFO")
+        return total_lines
+    try:
+        writer.close()
+    except Exception:
+        pass
+    log_message("❌ VanitySearch produced no output in any mode.", "ERROR")
+    return 0
 
-    order = [backend]
-    if backend == "cuda":
-        order = ["cuda", "opencl", "cpu"]
-    elif backend == "opencl":
-        order = ["opencl", "cpu"]
-    for b in order:
-        if _run_once(b):
-            return True
-    return False
-
-
-# Expose selected device info for callers
-get_selected_backend = lambda: _SELECTED_BACKEND
-get_selected_device_id = lambda: _SELECTED_DEVICE_ID
-get_selected_device_name = lambda: _SELECTED_DEVICE_NAME


### PR DESCRIPTION
## Summary
- Replace vanity runner to resolve binary lookup, disable bc1 by default, and rotate vanity output files safely
- Add ensure_dir helper and rolling writer for persistent VanitySearch output
- Restore canonical vanitysearch.exe name in settings

## Testing
- `python -m py_compile core/vanity_runner.py core/vanity_io.py config/settings.py`
- `pytest`
- `python main.py -only btc -funded --skip-downloads` *(fails: ModuleNotFoundError: No module named 'bitcoinaddress')*

------
https://chatgpt.com/codex/tasks/task_e_689fd3610f7c8327bfb5b1c436091be7