### PR TITLE
Fix vanity runner log_message import

### DIFF
--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -5,7 +5,7 @@ from config.settings import (
     VANITY_TXT_DIR, VANITY_ROTATE_LINES, VANITY_MAX_BYTES, ENABLE_BC1_DEFAULT
 )
 from core.vanity_io import RollingAtomicWriter, ensure_dir
-from core.dashboard import log_message
+from core.logger import log_message
 
 
 def _bin_dir() -> str:

--- a/core/worker_bootstrap.py
+++ b/core/worker_bootstrap.py
@@ -1,13 +1,14 @@
 import time
 
+from core.logger import log_message
+
 try:
-    from core.dashboard import init_shared_metrics, set_metric, increment_metric, log_message
+    from core.dashboard import init_shared_metrics, set_metric, increment_metric
 except Exception:
     # Fallback shims if dashboard import fails very early
     def init_shared_metrics(): return None
     def set_metric(*_a, **_k): return None
     def increment_metric(*_a, **_k): return None
-    def log_message(msg, level="INFO"): print(f"[{level}] {msg}")
 
 _metrics_ready = {"ok": False}
 


### PR DESCRIPTION
## Summary
- fix vanity_runner by importing log_message from core.logger instead of dashboard
- correct worker_bootstrap to log via core.logger and handle dashboard metrics separately

## Testing
- `python -m py_compile core/vanity_runner.py core/worker_bootstrap.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a001ae72408327bfbe5cba13f62d6c