### PR TITLE
Restore vanity runner interface and stabilize metrics initialization

### DIFF
--- a/core/alerts.py
+++ b/core/alerts.py
@@ -387,7 +387,7 @@ def trigger_startup_alerts(shared_metrics=None):
     """
     from core.worker_bootstrap import ensure_metrics_ready
     try:
-        ensure_metrics_ready()
+        ensure_metrics_ready(shared_metrics)
     except Exception:
         pass
     if not ENABLE_ALERTS:

--- a/core/altcoin_derive.py
+++ b/core/altcoin_derive.py
@@ -1021,7 +1021,7 @@ def convert_txt_to_csv_loop(shared_shutdown_event, shared_metrics=None, pause_ev
     initialize_logging(log_q)
     from core.worker_bootstrap import ensure_metrics_ready, _safe_set_metric, _safe_inc_metric
     try:
-        ensure_metrics_ready()
+        ensure_metrics_ready(shared_metrics)
         _safe_set_metric("status.altcoin", "Running")
         _safe_set_metric("altcoin_files_converted", 0)
         _safe_set_metric("derived_addresses_today", 0)

--- a/core/backlog.py
+++ b/core/backlog.py
@@ -62,7 +62,7 @@ def start_backlog_conversion_loop(shared_metrics=None, shutdown_event=None, paus
     from core.worker_bootstrap import ensure_metrics_ready, _safe_set_metric, _safe_inc_metric
     from core.dashboard import register_control_events
     try:
-        ensure_metrics_ready()
+        ensure_metrics_ready(shared_metrics)
         register_control_events(shutdown_event, pause_event, module="backlog")
     except Exception:
         pass

--- a/core/csv_checker.py
+++ b/core/csv_checker.py
@@ -420,7 +420,7 @@ def check_csvs_day_one(shared_metrics=None, shutdown_event=None, pause_event=Non
     initialize_logging(log_q)
     from core.worker_bootstrap import ensure_metrics_ready, _safe_set_metric, _safe_inc_metric
     try:
-        ensure_metrics_ready()
+        ensure_metrics_ready(shared_metrics)
         from core.dashboard import register_control_events
         register_control_events(shutdown_event, pause_event, module="csv_check")
         _safe_set_metric("status.csv_check", "Running")
@@ -492,7 +492,7 @@ def check_csvs(shared_metrics=None, shutdown_event=None, pause_event=None, safe_
     initialize_logging(log_q)
     from core.worker_bootstrap import ensure_metrics_ready, _safe_set_metric, _safe_inc_metric
     try:
-        ensure_metrics_ready()
+        ensure_metrics_ready(shared_metrics)
         from core.dashboard import register_control_events
         register_control_events(shutdown_event, pause_event, module="csv_recheck")
         _safe_set_metric("status.csv_recheck", "Running")

--- a/core/gpu_scheduler.py
+++ b/core/gpu_scheduler.py
@@ -71,7 +71,7 @@ def monitor_backlog_and_reassign(shared_metrics, vanity_flag, altcoin_flag, assi
     """
     from core.worker_bootstrap import ensure_metrics_ready, _safe_set_metric
     # Ensure dashboard helpers have access to the shared metrics dict
-    ensure_metrics_ready()
+    ensure_metrics_ready(shared_metrics)
 
     vendor, name = _detect_gpu_vendor()
     if name:

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -161,7 +161,7 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
     from core.worker_bootstrap import ensure_metrics_ready, _safe_set_metric
     from core.dashboard import register_control_events
     try:
-        ensure_metrics_ready()
+        ensure_metrics_ready(shared_metrics)
         logger.debug(f"Shared metrics initialized for {__name__}")
     except Exception as e:
         logger.exception(f"ensure_metrics_ready failed in {__name__}: {e}")

--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -1,112 +1,233 @@
-import os, shutil, subprocess, time
-from typing import List, Optional
+import os
+import re
+import subprocess
+import time
+from typing import Dict, List, Tuple, Optional
 
 from config.settings import (
-    VANITY_TXT_DIR, VANITY_ROTATE_LINES, VANITY_MAX_BYTES, ENABLE_BC1_DEFAULT
+    GPU_BACKEND,
+    FORCE_CPU_FALLBACK,
+    VANITYSEARCH_BIN_CUDA,
+    VANITYSEARCH_BIN_OPENCL,
+    VANITYSEARCH_BIN_CPU,
+    MIN_EXPECTED_GPU_MKEYS,
+    MAX_OUTPUT_FILE_SIZE,
+    ENABLE_P2WPKH,
+    ENABLE_TAPROOT,
+    DEFAULT_BTC_PATTERNS,
+    DEFAULT_BTC_PATTERNS_BECH32,
+    DEFAULT_BTC_PATTERNS_BECH32M,
 )
-from core.vanity_io import RollingAtomicWriter, ensure_dir
-from core.logger import log_message
+from core.logger import get_logger
+from core.dashboard import set_metric, update_dashboard_stat
+from core.utils.io_safety import atomic_open, atomic_commit
+
+logger = get_logger(__name__)
+logger.info("Atomic writes enabled for vanity outputs (temp → rename). Empty outputs are skipped.")
+
+# throttle warning frequency
+_LAST_WARN: Dict[str, float] = {}
 
 
-def _bin_dir() -> str:
-    return os.path.join(os.path.dirname(os.path.dirname(__file__)), "bin")
+def _warn_once(name: str, msg: str, interval: float = 30.0) -> None:
+    """Emit ``msg`` at most once per ``interval`` seconds for the given ``name``."""
+    now = time.time()
+    if now - _LAST_WARN.get(name, 0) >= interval:
+        logger.warning(msg)
+        _LAST_WARN[name] = now
 
 
-def _which(path: str) -> Optional[str]:
-    if os.path.isabs(path) and os.path.isfile(path):
-        return path
-    found = shutil.which(path)
-    return found if found else (path if os.path.isfile(path) else None)
-
-
-def _resolve_vanity_binaries() -> dict:
-    bin_dir = _bin_dir()
-    candidates = [
-        os.path.join(bin_dir, "vanitysearch.exe"),
-        os.path.join(bin_dir, "vanitysearch_cuda.exe"),
-        "vanitysearch.exe",
-        "vanitysearch_cuda.exe",
-    ]
-    exe = next((p for p in candidates if _which(p)), None)
-    return {"GPU": exe, "OPENCL": exe, "CPU": exe} if exe else {"GPU": None, "OPENCL": None, "CPU": None}
-
-
-def _build_patterns(patterns: Optional[List[str]]) -> List[str]:
-    pat_args: List[str] = []
-    if patterns:
-        for p in patterns:
-            if p and isinstance(p, str):
-                if p.lower().startswith("bc1") and not ENABLE_BC1_DEFAULT:
-                    continue
-                pat_args.extend(["-b", p])
-    return pat_args or ["-b", "1**"]
-
-
-def _popen_stream(args: List[str]) -> subprocess.Popen:
-    return subprocess.Popen(
-        args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
-        universal_newlines=True,
-        encoding="utf-8",
-        errors="replace",
-    )
-
-
-def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) -> int:
-    out_dir = ensure_dir(VANITY_TXT_DIR)
-    bins = _resolve_vanity_binaries()
-    if not any(bins.values()):
-        log_message("❌ VanitySearch binary not found (expected vanitysearch.exe).", "ERROR")
-        return 0
-    pat_args = _build_patterns(patterns)
-    base = ["-s", str(seed_start), "-q"] + pat_args
-    modes = [("GPU", ["-gpu"]), ("OPENCL", ["-opencl"]), ("CPU", ["-cpu"])]
-    writer = RollingAtomicWriter(out_dir, rotate_lines=VANITY_ROTATE_LINES,
-                                 max_bytes=VANITY_MAX_BYTES, prefix="vanity")
-    total_lines = 0
-    for mode_name, mode_flag in modes:
-        exe = bins.get(mode_name)
-        if not exe:
-            continue
-        args = [exe] + base + mode_flag
-        try:
-            log_message(f"🧪 Trying VanitySearch ({mode_name}): {' '.join(args)}", "INFO")
-            proc = _popen_stream(args)
-            last_ts = time.time()
-            while True:
-                if stop_event and stop_event.is_set():
-                    proc.terminate(); break
-                line = proc.stdout.readline()
-                if not line:
-                    if proc.poll() is not None:
-                        break
-                    if time.time() - last_ts > 5:
-                        log_message("⏳ VanitySearch running (no output yet)...", "DEBUG")
-                        last_ts = time.time()
-                    time.sleep(0.05)
-                    continue
-                last_ts = time.time()
-                if ("1" in line) or ("3" in line) or ("bc1" in line):
-                    writer.write_line(line.rstrip("\n"))
-                    total_lines += 1
-            rc = proc.wait(timeout=10)
-            if rc == 0 and total_lines > 0:
-                log_message(f"✅ VanitySearch finished ({mode_name}) with {total_lines} lines.", "SUCCESS")
-                writer.close(); return total_lines
-            log_message(f"⚠️ VanitySearch exited rc={rc}, lines={total_lines}. Trying next mode...", "WARNING")
-        except Exception as e:
-            log_message(f"⚠️ VanitySearch {mode_name} mode failed: {e}", "WARNING")
-            continue
-    if total_lines > 0:
-        writer.close()
-        log_message(f"✅ Finalized partial output with {total_lines} lines after fallbacks.", "INFO")
-        return total_lines
+def _run_binary(binary: str, args: List[str]) -> str:
     try:
-        writer.close()
-    except Exception:
-        pass
-    log_message("❌ VanitySearch produced no output in any mode.", "ERROR")
-    return 0
+        return subprocess.check_output([binary] + args, stderr=subprocess.STDOUT, text=True)
+    except Exception as exc:
+        logger.debug(f"Device probe failed for {binary}: {exc}")
+        return ""
 
+
+def list_devices() -> Dict[str, List[Tuple[int, str]]]:
+    """Return available GPU devices for CUDA and OpenCL binaries."""
+    devices: Dict[str, List[Tuple[int, str]]] = {}
+    binaries = {
+        "cuda": VANITYSEARCH_BIN_CUDA,
+        "opencl": VANITYSEARCH_BIN_OPENCL,
+    }
+    for backend, bin_path in binaries.items():
+        if not os.path.exists(bin_path):
+            continue
+        out = _run_binary(bin_path, ["-l"])
+        entries: List[Tuple[int, str]] = []
+        for line in out.splitlines():
+            m = re.search(r"#(\d+)\s+(.+)$", line)
+            if m:
+                entries.append((int(m.group(1)), m.group(2).strip()))
+        if entries:
+            devices[backend] = entries
+    return devices
+
+
+_SELECTED_BACKEND: str = "cpu"
+_SELECTED_DEVICE_ID: Optional[int] = None
+_SELECTED_DEVICE_NAME: str = "CPU"
+_SELECTED_BINARY: str = VANITYSEARCH_BIN_CPU
+
+
+def resolve_vanitysearch_binary(backend: str) -> str:
+    """Return the VanitySearch binary path for ``backend``."""
+    if backend == "cuda":
+        return VANITYSEARCH_BIN_CUDA
+    if backend == "opencl":
+        return VANITYSEARCH_BIN_OPENCL
+    return VANITYSEARCH_BIN_CPU
+
+
+def probe_device() -> Tuple[str, Optional[int], str, str]:
+    """Select appropriate backend/device based on settings and availability."""
+    global _SELECTED_BACKEND, _SELECTED_DEVICE_ID, _SELECTED_DEVICE_NAME, _SELECTED_BINARY
+
+    devices = list_devices()
+    backend = "cpu"
+    device_id: Optional[int] = None
+    device_name = "CPU"
+
+    if not FORCE_CPU_FALLBACK:
+        if GPU_BACKEND in ("cuda", "opencl") and devices.get(GPU_BACKEND):
+            backend = GPU_BACKEND
+            device_id, device_name = devices[GPU_BACKEND][0]
+        elif GPU_BACKEND == "auto":
+            for cand in ("cuda", "opencl"):
+                if devices.get(cand):
+                    backend = cand
+                    device_id, device_name = devices[cand][0]
+                    break
+
+    binary = resolve_vanitysearch_binary(backend)
+    if backend in ("cuda", "opencl") and not os.path.exists(binary):
+        _warn_once("binary_missing", f"GPU backend {backend} selected but binary missing. Falling back to CPU")
+        backend = "cpu"
+        device_id = None
+        device_name = "CPU"
+        binary = resolve_vanitysearch_binary("cpu")
+
+    if backend != "cpu" and FORCE_CPU_FALLBACK:
+        _warn_once("cpu_forced", "GPU available but FORCE_CPU_FALLBACK=True; using CPU")
+        backend = "cpu"
+        device_id = None
+        device_name = "CPU"
+        binary = resolve_vanitysearch_binary("cpu")
+
+    if backend == "cpu" and GPU_BACKEND != "cpu":
+        _warn_once("cpu_fallback", "GPU backend requested but CPU binary selected")
+
+    _SELECTED_BACKEND = backend
+    _SELECTED_DEVICE_ID = device_id
+    _SELECTED_DEVICE_NAME = device_name
+    _SELECTED_BINARY = binary
+
+    update_dashboard_stat({
+        "vanitysearch_backend": backend,
+        "vanitysearch_device_name": device_name,
+    })
+    logger.info(
+        f"VanitySearch device: {device_name} | backend: {backend} | binary: {binary} | FORCE_CPU_FALLBACK={FORCE_CPU_FALLBACK}"
+    )
+    return backend, device_id, device_name, binary
+
+
+def build_vanitysearch_args(hex_seed: str) -> List[Tuple[List[str], str]]:
+    """Return a list of argument lists for each enabled address type."""
+    jobs: List[Tuple[List[str], str]] = []
+    jobs.append((["-s", hex_seed, "-u", DEFAULT_BTC_PATTERNS[0]], "p2pkh"))
+    if ENABLE_P2WPKH:
+        jobs.append((["-s", hex_seed, "-u", DEFAULT_BTC_PATTERNS_BECH32[0]], "p2wpkh"))
+    if ENABLE_TAPROOT:
+        jobs.append((["-s", hex_seed, "-u", DEFAULT_BTC_PATTERNS_BECH32M[0]], "taproot"))
+    return jobs
+
+
+def run_vanitysearch(
+    seed_args: List[str],
+    output_path: str,
+    device_id: Optional[int],
+    backend: str,
+    timeout: int = 60,
+    pause_event=None,
+    addr_mode: str = "p2pkh",
+) -> bool:
+    """Execute VanitySearch with live speed parsing and atomic output handling."""
+    if pause_event and pause_event.is_set():
+        logger.info("Keygen paused; skipping VanitySearch job")
+        return False
+
+    binary = resolve_vanitysearch_binary(backend)
+    cmd = [binary] + seed_args
+    if backend in ("cuda", "opencl") and device_id is not None:
+        cmd += ["-gpu", str(device_id)]
+    update_dashboard_stat("vanitysearch_addr_mode", addr_mode)
+    logger.info(f"Executing: {' '.join(cmd)}")
+
+    tmp_path, tmp_handle = atomic_open(output_path)
+    buffer: List[str] = []
+    valid_lines = 0
+    addr_re = re.compile(
+        r"^(?:PubAddr|PubAddress)\s*:\s*(\S+)|"  # legacy marker
+        r"^(1[1-9A-HJ-NP-Za-km-z]{25,34}|3[1-9A-HJ-NP-Za-km-z]{25,34}|bc1[0-9ac-hj-np-z]{11,71})$",
+        re.IGNORECASE,
+    )
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        start = time.time()
+        for line in proc.stdout:
+            buffer.append(line)
+            m = re.search(r"([0-9.]+)\s*([MK])?Key/s", line, re.IGNORECASE)
+            if m:
+                speed = float(m.group(1))
+                if m.group(2) and m.group(2).upper() == "K":
+                    speed /= 1000.0
+                update_dashboard_stat("vanitysearch_current_mkeys", round(speed, 2))
+                if backend != "cpu" and speed < MIN_EXPECTED_GPU_MKEYS:
+                    _warn_once("low_speed", "Speed suggests CPU; check GPU selection")
+
+            if addr_re.match(line.strip()):
+                valid_lines += 1
+                if valid_lines == 1:
+                    tmp_handle.writelines(buffer)
+                else:
+                    tmp_handle.write(line)
+            elif valid_lines > 0:
+                tmp_handle.write(line)
+
+            if pause_event and pause_event.is_set():
+                proc.terminate()
+            if timeout and time.time() - start > timeout:
+                proc.terminate()
+            if os.path.exists(tmp_path) and os.path.getsize(tmp_path) >= MAX_OUTPUT_FILE_SIZE:
+                proc.terminate()
+        proc.wait()
+    except Exception:
+        logger.exception("Failed to execute VanitySearch")
+        tmp_handle.close()
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        return False
+
+    tmp_handle.close()
+    if valid_lines == 0:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        logger.info(f"No address lines emitted by VanitySearch for {addr_mode}")
+        return False
+
+    atomic_commit(tmp_path, output_path)
+    return True
+
+
+# Expose selected device info for callers
+get_selected_backend = lambda: _SELECTED_BACKEND
+get_selected_device_id = lambda: _SELECTED_DEVICE_ID
+get_selected_device_name = lambda: _SELECTED_DEVICE_NAME

--- a/core/worker_bootstrap.py
+++ b/core/worker_bootstrap.py
@@ -12,12 +12,13 @@ except Exception:
 
 _metrics_ready = {"ok": False}
 
-def ensure_metrics_ready():
+
+def ensure_metrics_ready(shared_dict=None):
     """Idempotently initialize metrics in THIS process and write a heartbeat."""
     if _metrics_ready["ok"]:
         return True
     try:
-        init_shared_metrics()               # safe if already inited elsewhere
+        init_shared_metrics(shared_dict)  # safe if already inited elsewhere
         set_metric("_worker_heartbeat", int(time.time()))
         _metrics_ready["ok"] = True
         log_message("[worker_bootstrap] Shared metrics initialized", "DEBUG")

--- a/main.py
+++ b/main.py
@@ -104,7 +104,7 @@ from core.gpu_selector import (
 def metrics_updater(shared_metrics=None):
     from core.worker_bootstrap import ensure_metrics_ready, _safe_set_metric, _safe_inc_metric
     try:
-        ensure_metrics_ready()
+        ensure_metrics_ready(shared_metrics)
         print("[debug] Shared metrics initialized for", __name__, flush=True)
     except Exception as e:
         print(f"[error] ensure_metrics_ready failed in {__name__}: {e}", flush=True)


### PR DESCRIPTION
## Summary
- Reintroduce GPU probing and VanitySearch helpers in `vanity_runner` to restore `probe_device` and command builders.
- Prevent `multiprocessing.Manager` from spawning in daemon workers by accepting shared metrics dicts in `init_shared_metrics` and `ensure_metrics_ready`.
- Pass shared metrics to all worker processes to avoid `daemonic processes are not allowed to have children` errors.

## Testing
- `python -m py_compile core/vanity_runner.py core/dashboard.py core/worker_bootstrap.py main.py core/keygen.py core/csv_checker.py core/alerts.py core/altcoin_derive.py core/backlog.py core/gpu_scheduler.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a006d5d9d88327a16b82415b65dcb8