### PR TITLE
Use bundled CUDA VanitySearch binary

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -33,7 +33,8 @@ START_BATCH_ID = 0
 USE_CUSTOM_SEEDS = False
 
 # ===================== 🚀 VANITY SEARCH CONFIG ====================
-VANITYSEARCH_PATH = "D:/Downloads/VanitySearch.exe"
+# Path to the bundled VanitySearch binary (CUDA only)
+VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", "VanitySearch.exe")
 PATTERN = "1**"  # Only search for addresses starting with '1'
 VANITYSEARCH_GPU_INDEX = [0]  # Default to GPU 0; override at runtime
 USE_CPU_FALLBACK = True

--- a/config/settings.py
+++ b/config/settings.py
@@ -58,8 +58,9 @@ BTC_MIN_FILE_AGE_SEC = 2.0            # ignore files newer than this
 
 # --- VanitySearch Settings ---
 VANITY_PATTERN = "1**"  # Change this pattern to match your target (e.g., starts with 1)
-VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", "vanitysearch.exe")  # Adjust if renamed
-VANITYSEARCH_EXE_NAME = "vanitysearch.exe"
+# Single VanitySearch binary (CUDA only)
+VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", "VanitySearch.exe")
+VANITYSEARCH_EXE_NAME = "VanitySearch.exe"
 MAX_KEYS_PER_FILE = 100_000  #Deprecated
 # Output file rotation config (for VanitySearch stream)
 VANITY_ROTATE_LINES = 200_000
@@ -648,10 +649,11 @@ BUTTONS_ENABLED = {
 
 # ===================== 🖥️ GPU/CPU BACKENDS ==========================
 # GPU/CPU selection & binaries
-GPU_BACKEND = "auto"        # "cuda" | "opencl" | "auto"
-VANITYSEARCH_BIN_CUDA = os.path.join(BASE_DIR, "bin", "vanitysearch_cuda.exe")
-VANITYSEARCH_BIN_OPENCL = os.path.join(BASE_DIR, "bin", "vanitysearch_opencl.exe")
-VANITYSEARCH_BIN_CPU = VANITYSEARCH_PATH  # fallback only
+# Only the CUDA-enabled VanitySearch binary is bundled.
+GPU_BACKEND = "cuda"        # CUDA is the only supported backend
+VANITYSEARCH_BIN_CUDA = VANITYSEARCH_PATH
+VANITYSEARCH_BIN_OPENCL = ""  # placeholder for future OpenCL support
+VANITYSEARCH_BIN_CPU = VANITYSEARCH_PATH  # CPU fallback shares the same binary
 
 FORCE_CPU_FALLBACK = False  # If True, run CPU even if GPU available
 MIN_EXPECTED_GPU_MKEYS = 120.0  # GTX 1060 typical: 150–230 MKeys/s


### PR DESCRIPTION
## Summary
- Point VanitySearch settings to the included `bin/VanitySearch.exe`
- Default GPU backend to CUDA and remove references to missing binaries
- Update legacy config to use bundled VanitySearch path

## Testing
- `python -m py_compile config/settings.py`
- `python - <<'PY'
import os
from config import settings
print('path:', settings.VANITYSEARCH_PATH)
print('exists:', os.path.exists(settings.VANITYSEARCH_PATH))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a128b996a883278bd64cf21ce39333