### PR TITLE
refactor: restore direct VanitySearch stream

### DIFF
--- a/core/keygen.py
+++ b/core/keygen.py
@@ -7,22 +7,25 @@ import secrets
 from datetime import datetime
 from collections import deque
 from config.settings import (
+    VANITYSEARCH_PATH,
     VANITY_OUTPUT_DIR,
+    VANITY_PATTERN,
     BATCH_SIZE,
     ADDR_PER_FILE,
     CHECKPOINT_PATH,
+    MAX_OUTPUT_FILE_SIZE,
     MAX_OUTPUT_LINES,
     ROTATE_INTERVAL_SECONDS,
     FILES_PER_BATCH,
     FORCE_CPU_FALLBACK
-
 )
 
 from config.constants import SECP256K1_ORDER
 from core.checkpoint import load_keygen_checkpoint as load_checkpoint, save_keygen_checkpoint as save_checkpoint
 from core.logger import get_logger
-from core import vanity_runner
+from core.gpu_selector import get_vanitysearch_gpu_ids
 from core.csv_checker import detect_btc_address_type, normalize_address
+from core.dashboard import init_shared_metrics, set_metric, increment_metric, get_metric
 
 
 # Runtime trackers
@@ -83,91 +86,200 @@ def generate_random_seed(min_bits=128):
 
 
 def run_vanitysearch_stream(initial_seed_int, batch_id, index_within_batch, pause_event=None, gpu_flag=None):
-    """Run VanitySearch once and return when the output file is rotated.
-
-    Returns ``True`` if the file was generated successfully, ``False`` if the
-    process was interrupted (e.g. via the pause button).
     """
+    Launch VanitySearch once, stream stdout directly to a uniquely named file,
+    and rotate by time/size. On completion, update all metrics and per-type
+    address counts. Returns True if a non-empty file was produced; False otherwise.
+
+    Preserves the proven behavior from the older working keygen while
+    maintaining the newer centralized metrics/dashboard logic.
+    """
+    import subprocess
+    import threading
+
     global total_keys_generated, last_output_file
 
+    # Resolve GPU usage: FORCE_CPU_FALLBACK overrides UI flag.
+    use_gpu = True
+    if gpu_flag is not None:
+        try:
+            use_gpu = bool(gpu_flag.value)
+        except Exception:
+            use_gpu = True
+    if FORCE_CPU_FALLBACK:
+        use_gpu = False
+
+    # Select NVIDIA GPUs if allowed, otherwise CPU
+    try:
+        selected_gpu_ids = get_vanitysearch_gpu_ids() if use_gpu else []
+    except Exception:
+        selected_gpu_ids = []
+    gpu_env = {"CUDA_VISIBLE_DEVICES": ",".join(map(str, selected_gpu_ids))} if selected_gpu_ids else {}
+
+    # Seed formatting for vanitysearch
     hex_seed_full = hex(initial_seed_int)[2:].rjust(64, "0")
     hex_seed_short = hex(initial_seed_int)[2:].lstrip("0")[:8] or "00000000"
 
+    # Output path
     current_output_path = os.path.join(
         VANITY_OUTPUT_DIR,
         f"batch_{batch_id}_part_{index_within_batch}_seed_{hex_seed_short}.txt"
     )
-    backend = vanity_runner.get_selected_backend()
-    device_id = vanity_runner.get_selected_device_id()
-    jobs = vanity_runner.build_vanitysearch_args(hex_seed_full)
-    any_success = False
-    from core.worker_bootstrap import _safe_inc_metric
-    for args, mode in jobs:
-        current_output_path = os.path.join(
-            VANITY_OUTPUT_DIR,
-            f"batch_{batch_id}_part_{index_within_batch}_seed_{hex_seed_short}_{mode}.txt",
-        )
-        last_output_file = current_output_path
-        success = vanity_runner.run_vanitysearch(
-            args,
-            current_output_path,
-            device_id,
-            backend,
-            timeout=ROTATE_INTERVAL_SECONDS,
-            pause_event=pause_event,
-            addr_mode=mode,
-        )
-        if not success:
-            continue
-        any_success = True
-        if os.path.exists(current_output_path):
-            size = os.path.getsize(current_output_path)
-            if size == 0:
-                logger.warning(f"⚠️ Output file empty: {current_output_path}")
+    last_output_file = current_output_path
+
+    # Build command
+    cmd = [VANITYSEARCH_PATH, "-s", hex_seed_full, "-o", current_output_path, "-u", VANITY_PATTERN]
+    if use_gpu and selected_gpu_ids:
+        cmd.insert(1, "-gpu")
+
+    logger.info(
+        "🧬 Starting VanitySearch\n"
+        f"   Seed:    {hex_seed_full}\n"
+        f"   Output:  {current_output_path}\n"
+        f"   Backend: {'GPU:'+','.join(map(str, selected_gpu_ids)) if (use_gpu and selected_gpu_ids) else 'CPU'}\n"
+        f"   Command: {' '.join(cmd)}"
+    )
+
+    # Respect pending pause
+    if pause_event and pause_event.is_set():
+        logger.info("⏸️ Pause detected before launch. Skipping VanitySearch run.")
+        return False
+
+    # Launch and monitor
+    try:
+        with open(current_output_path, "w", encoding="utf-8", buffering=1) as outfile:
+            logger.debug(f"Opened {current_output_path} for writing")
+            proc = subprocess.Popen(
+                cmd,
+                stdout=outfile,
+                stderr=subprocess.STDOUT,
+                env={**os.environ, **gpu_env},
+            )
+            logger.info(f"Spawned VanitySearch PID {proc.pid}")
+
+            def monitor_process(p, path):
+                start_ts = time.time()
+                while p.poll() is None:
+                    # Pause handling
+                    if pause_event and pause_event.is_set():
+                        logger.info("⏸️ Pause requested. Terminating VanitySearch for clean rotation...")
+                        p.terminate()
+                        break
+
+                    # Time-based rotation
+                    if ROTATE_INTERVAL_SECONDS and (time.time() - start_ts >= ROTATE_INTERVAL_SECONDS):
+                        logger.info("⏱️ Rotation interval reached. Terminating for rotation.")
+                        p.terminate()
+                        break
+
+                    # Size-based rotation
+                    try:
+                        if MAX_OUTPUT_FILE_SIZE and os.path.getsize(path) >= MAX_OUTPUT_FILE_SIZE:
+                            logger.info(f"📏 Max size reached ({MAX_OUTPUT_FILE_SIZE} bytes). Rotating.")
+                            p.terminate()
+                            break
+                    except FileNotFoundError:
+                        pass
+
+                    time.sleep(1)
+
+            watcher = threading.Thread(target=monitor_process, args=(proc, current_output_path), daemon=True)
+            watcher.start()
+            proc.wait()
+            watcher.join()
+
+    except Exception as e:
+        logger.exception(f"Failed to execute VanitySearch: {e}")
+        try:
+            if os.path.exists(current_output_path) and os.path.getsize(current_output_path) == 0:
                 os.remove(current_output_path)
-                continue
-            try:
-                with open(current_output_path, 'r', encoding='utf-8') as f:
-                    logger.info(f"Opened {current_output_path} for reading")
-                    lines = 0
-                    for line in f:
-                        parts = line.strip().split()
-                        if not parts:
-                            continue
-                        addr = normalize_address(parts[0])
-                        atype = detect_btc_address_type(addr)
-                        _safe_inc_metric(f"addresses_generated_today.{atype}", 1)
-                        _safe_inc_metric(f"addresses_generated_lifetime.{atype}", 1)
-                        lines += 1
-                    total_keys_generated += lines
-                    _safe_inc_metric("keys_generated_today", lines)
-                    _safe_inc_metric("keys_generated_lifetime", lines)
-                    _safe_inc_metric("addresses_generated_today.btc", lines)
-                    _safe_inc_metric("addresses_generated_lifetime.btc", lines)
-                    from core.dashboard import update_dashboard_stat, get_metric
-                    update_dashboard_stat("keys_generated_today", get_metric("keys_generated_today"))
-                    update_dashboard_stat("keys_generated_lifetime", get_metric("keys_generated_lifetime"))
-                    logger.info(f"📄 File complete: {lines} lines → {current_output_path}")
-            except Exception as e:
-                logger.warning(f"⚠️ Failed to count lines in {current_output_path}: {e}")
-    return any_success
+        except Exception:
+            pass
+        return False
 
+    # Post-run checks
+    if not os.path.exists(current_output_path):
+        logger.error(f"❌ Output file not created: {current_output_path}")
+        return False
 
+    size = os.path.getsize(current_output_path)
+    if size == 0:
+        logger.warning(f"⚠️ Output file empty: {current_output_path}")
+        try:
+            os.remove(current_output_path)
+        except Exception:
+            pass
+        return False
 
-from core.dashboard import get_metric
+    # Count lines + update metrics (per-type + aggregate)
+    lines = 0
+    try:
+        try:
+            from core.worker_bootstrap import _safe_inc_metric as inc_m
+        except Exception:
+            inc_m = increment_metric
+
+        with open(current_output_path, "r", encoding="utf-8") as f:
+            for raw in f:
+                s = raw.strip()
+                if not s:
+                    continue
+                addr = normalize_address(s.split()[0])
+                atype = detect_btc_address_type(addr)
+                inc_m(f"addresses_generated_today.{atype}", 1)
+                inc_m(f"addresses_generated_lifetime.{atype}", 1)
+                inc_m("addresses_generated_today.btc", 1)
+                inc_m("addresses_generated_lifetime.btc", 1)
+                lines += 1
+
+        total_keys_generated += lines
+        inc_m("keys_generated_today", lines)
+        inc_m("keys_generated_lifetime", lines)
+
+        try:
+            from core.dashboard import update_dashboard_stat, get_metric as get_m
+            update_dashboard_stat("keys_generated_today", get_m("keys_generated_today"))
+            update_dashboard_stat("keys_generated_lifetime", get_m("keys_generated_lifetime"))
+        except Exception:
+            pass
+
+        logger.info(f"📄 File complete: {lines} lines → {current_output_path}")
+
+    except Exception as e:
+        logger.warning(f"⚠️ Failed to post-process {current_output_path}: {e}")
+
+    return True
+
 
 
 def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None, gpu_flag=None):
-    from core.worker_bootstrap import ensure_metrics_ready, _safe_set_metric
-    from core.dashboard import register_control_events
+    """
+    Main key generation loop. Keeps all dashboard/metrics/pause logic intact,
+    removes hard dependency on GPU probing (CPU fallback is automatic), and
+    preserves checkpointing across batches and files.
+    """
+    # Prefer safe worker bootstrap helpers, fallback to dashboard init
     try:
-        ensure_metrics_ready(shared_metrics)
+        from core.worker_bootstrap import ensure_metrics_ready as _ensure_ready, _safe_set_metric as set_m
+        _ensure_ready(shared_metrics)
         logger.debug(f"Shared metrics initialized for {__name__}")
-    except Exception as e:
-        logger.exception(f"ensure_metrics_ready failed in {__name__}: {e}")
+    except Exception:
+        try:
+            init_shared_metrics(shared_metrics)
+            logger.debug(f"Shared metrics initialized (fallback) for {__name__}")
+        except Exception as e:
+            logger.exception(f"Failed to initialize shared metrics in {__name__}: {e}")
+        def set_m(k, v):
+            try:
+                set_metric(k, v)
+            except Exception:
+                pass
+
+    from core.dashboard import register_control_events, set_thread_health, get_shutdown_event, get_pause_event
     register_control_events(shutdown_event, pause_event, module="keygen")
     os.makedirs(VANITY_OUTPUT_DIR, exist_ok=True)
 
+    # Load or init checkpoint
     checkpoint = load_checkpoint()
     if checkpoint:
         KEYGEN_STATE["batch_id"] = checkpoint.get("batch_id", 0)
@@ -178,35 +290,19 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
         KEYGEN_STATE["index_within_batch"] = secrets.randbelow(FILES_PER_BATCH)
         logger.info("🚀 No checkpoint found. Starting with randomized batch/index.")
 
-    # Initialize dashboard metrics so the GUI never shows N/A
-    _safe_set_metric("keys_generated_today", 0)
-    _safe_set_metric("vanity_progress_percent", 0)
-    _safe_set_metric("current_seed_index", KEYGEN_STATE["index_within_batch"])
+    # Initialize UI metrics
+    set_m("keys_generated_today", 0)
+    set_m("vanity_progress_percent", 0)
+    set_m("current_seed_index", KEYGEN_STATE["index_within_batch"])
 
+    # Mark running
     try:
-        backend, device_id, device_name, binary = vanity_runner.probe_device()
-        logger.info(
-            f"Startup selection → device: {device_name} | backend: {backend} | binary: {binary} | FORCE_CPU_FALLBACK={FORCE_CPU_FALLBACK}"
-        )
-    except RuntimeError as exc:
-        logger.error(f"GPU probe failed: {exc}")
-        from core.dashboard import set_thread_health
-        _safe_set_metric("status.keygen", "Stopped")
-        try:
-            set_thread_health("keygen", False)
-        except Exception:
-            pass
-        return
-
-    try:
-        _safe_set_metric("status.keygen", "Running")
-        from core.dashboard import (
-            set_thread_health,
-            get_shutdown_event,
-            get_pause_event,
-        )
+        set_m("status.keygen", "Running")
         set_thread_health("keygen", True)
+    except Exception:
+        pass
 
+    try:
         shutdown_evt = get_shutdown_event("keygen")
         pause_evt = get_pause_event("keygen")
 
@@ -219,9 +315,8 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
             if shutdown_evt and shutdown_evt.is_set():
                 break
 
+            # Pause heartbeat (rate-limited)
             if pause_evt and pause_evt.is_set():
-                # Emit a heartbeat log every 5s while paused so the user knows
-                # the key generator is still alive.
                 if (not pause_logged) or (time.time() - pause_log_ts > 5):
                     logger.info("⏸️ Keygen paused. Waiting to resume...")
                     pause_logged = True
@@ -232,39 +327,45 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
                 logger.info("▶️ Keygen resumed.")
                 pause_logged = False
 
-            # update keys/sec using a moving window of the last 5 seconds
+            # Update keys/sec (5s window)
             now = time.time()
-            current_keys = get_metric("keys_generated_today", 0)
+            try:
+                current_keys = get_metric("keys_generated_today", 0)
+            except Exception:
+                current_keys = 0
             KPS_WINDOW.append((now, current_keys))
             while KPS_WINDOW and now - KPS_WINDOW[0][0] > 5:
                 KPS_WINDOW.popleft()
             if len(KPS_WINDOW) >= 2:
-                kps = (current_keys - KPS_WINDOW[0][1]) / (now - KPS_WINDOW[0][0])
+                kps = (current_keys - KPS_WINDOW[0][1]) / max(1e-6, (now - KPS_WINDOW[0][0]))
             else:
                 kps = 0
-            _safe_set_metric("keys_per_sec", round(kps, 2))
+            set_m("keys_per_sec", round(kps, 2))
 
+            # Batch loop
             batch_start = time.perf_counter()
             index = KEYGEN_STATE["index_within_batch"]
+
             while index < FILES_PER_BATCH:
                 if shutdown_evt and shutdown_evt.is_set():
                     break
                 if pause_evt and pause_evt.is_set():
-                    # Inner-loop pause check to halt new VanitySearch runs
-                    _safe_set_metric("keys_per_sec", 0)
+                    set_m("keys_per_sec", 0)
                     time.sleep(1)
                     continue
 
+                # Random seed (swap to generate_seed_from_batch() if deterministic is desired)
                 seed = generate_random_seed()
 
                 KEYGEN_STATE["index_within_batch"] = index
                 KEYGEN_STATE["last_seed"] = hex(seed)[2:].rjust(64, "0")
-                _safe_set_metric("current_seed_index", index)
-                progress = round((index / float(FILES_PER_BATCH)) * 100, 2)
-                _safe_set_metric("vanity_progress_percent", progress)
+                set_m("current_seed_index", index)
 
-                success = run_vanitysearch_stream(seed, KEYGEN_STATE["batch_id"], index, pause_evt, gpu_flag)
-                if not success:
+                progress = round((index / float(FILES_PER_BATCH)) * 100, 2)
+                set_m("vanity_progress_percent", progress)
+
+                ok = run_vanitysearch_stream(seed, KEYGEN_STATE["batch_id"], index, pause_evt, gpu_flag)
+                if not ok:
                     time.sleep(1)
                     continue
 
@@ -275,17 +376,19 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
                 })
                 index += 1
 
+            # Batch done → update timing/averages
             batch_end = time.perf_counter()
             batches_completed += 1
-            total_time += batch_end - batch_start
-            _safe_set_metric("batches_completed", batches_completed)
-            _safe_set_metric("avg_keygen_time", round(total_time / batches_completed, 2))
+            total_time += (batch_end - batch_start)
+            set_m("batches_completed", batches_completed)
+            set_m("avg_keygen_time", round(total_time / max(1, batches_completed), 2))
             logger.info(f"Batch {KEYGEN_STATE['batch_id']} completed")
 
+            # Next batch
             KEYGEN_STATE["batch_id"] += 1
             KEYGEN_STATE["index_within_batch"] = 0
-            _safe_set_metric("vanity_progress_percent", 0)
-            # Record start of next batch so restarts begin at correct position
+            set_m("vanity_progress_percent", 0)
+
             save_checkpoint({
                 "batch_id": KEYGEN_STATE["batch_id"],
                 "index_within_batch": 0,
@@ -293,16 +396,14 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
 
     except KeyboardInterrupt:
         logger.info("🛑 Keygen loop interrupted by user. Exiting cleanly.")
-    except Exception as e:
-        # Log full stack trace for any unexpected failure
+    except Exception:
         logger.exception("❌ Unexpected error in keygen loop")
     finally:
-        _safe_set_metric("status.keygen", "Stopped")
         try:
-            from core.dashboard import set_thread_health
+            set_m("status.keygen", "Stopped")
             set_thread_health("keygen", False)
         except Exception:
-            logger.warning("Failed to update keygen thread health", exc_info=True)
+            pass
 
 
 # 🧪 One-time run (for debugging only)


### PR DESCRIPTION
## Summary
- remove fragile vanity_runner dependency from keygen
- stream VanitySearch output directly with rotation and metrics
- simplify keygen loop with automatic CPU fallback

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a4733b3d288327b24d6d35bd4e2f88