### PR TITLE
Stream VanitySearch output to rolling files

### DIFF
--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -337,8 +337,6 @@ def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) 
     base = [exe, "-s", seed, "-q"]
     _apply_mode_flags(base)
 
-    # Use temporary output files with the -o flag so results are captured
-    # reliably even if VanitySearch alters its stdout behaviour.
     modes = [
         ("GPU", ["-gpu"]),
         ("OPENCL", ["-opencl"]),
@@ -349,7 +347,7 @@ def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) 
     tmpfile = None
     try:
         if len(pats) == 1:
-            single_suffix = [pats[0]]  # final positional argument
+            single_suffix = [pats[0]]
             multi_suffix: List[str] = []
         else:
             fd, tmpfile = tempfile.mkstemp(prefix="vanity_prefixes_", suffix=".txt", dir=out_dir)
@@ -358,10 +356,6 @@ def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) 
             single_suffix = []
             multi_suffix = ["-i", tmpfile]
 
-        writer = RollingAtomicWriter(
-            out_dir, rotate_lines=VANITY_ROTATE_LINES, max_bytes=VANITY_MAX_BYTES, prefix="vanity"
-        )
-        total_lines = 0
         addr_re = re.compile(
             r"^(?:PubAddr(?:ess)?\s*:\s*)?"  # optional "PubAddress:" prefix
             r"(1[1-9A-HJ-NP-Za-km-z]{25,34}|"  # legacy Base58 addresses
@@ -372,13 +366,13 @@ def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) 
 
         for mode_name, mode_flag in modes:
             args = base + mode_flag + multi_suffix + single_suffix
-            tmp_out = None
+            writer = RollingAtomicWriter(
+                out_dir, rotate_lines=VANITY_ROTATE_LINES, max_bytes=VANITY_MAX_BYTES, prefix="vanity"
+            )
+            total_lines = 0
             try:
-                fd, tmp_out = tempfile.mkstemp(prefix="vanity_tmp_", suffix=".txt", dir=out_dir)
-                os.close(fd)
-                args_with_out = args + ["-o", tmp_out]
-                log_message(f"🧪 VanitySearch ({mode_name}): {' '.join(args_with_out)}", "INFO")
-                proc = _popen_stream(args_with_out)
+                log_message(f"🧪 VanitySearch ({mode_name}): {' '.join(args)}", "INFO")
+                proc = _popen_stream(args)
                 last_line_ts = time.time()
 
                 while True:
@@ -397,19 +391,14 @@ def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) 
                         continue
 
                     last_line_ts = time.time()
+                    striped = line.rstrip("\n")
+                    if striped:
+                        writer.write_line(striped)
+                        if addr_re.match(striped):
+                            total_lines += 1
 
                 rc = proc.wait(timeout=10)
-                if os.path.exists(tmp_out):
-                    with open(tmp_out, "r", encoding="utf-8", errors="replace") as fh:
-                        for out_line in fh:
-                            striped = out_line.rstrip("\n")
-                            if striped:
-                                writer.write_line(striped)
-                                if addr_re.match(striped):
-                                    total_lines += 1
-                    os.remove(tmp_out)
-
-                if rc == 0 and total_lines > 0:
+                if total_lines > 0:
                     log_message(
                         f"✅ VanitySearch finished ({mode_name}) with {total_lines} matches.",
                         "SUCCESS",
@@ -421,24 +410,12 @@ def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) 
                         f"⚠️ VanitySearch exited rc={rc}, matches={total_lines}. Trying next mode...",
                         "WARNING",
                     )
+                    writer.abort()
             except Exception as e:
                 log_message(f"⚠️ VanitySearch {mode_name} failed: {e}", "WARNING")
-                if tmp_out and os.path.exists(tmp_out):
-                    try:
-                        os.remove(tmp_out)
-                    except Exception:
-                        pass
+                writer.abort()
                 continue
 
-        if total_lines > 0:
-            writer.close()
-            log_message(
-                f"✅ Finalized partial output with {total_lines} matches after fallbacks.",
-                "INFO",
-            )
-            return total_lines
-
-        writer.abort()
         log_message("❌ VanitySearch produced no output in any mode.", "ERROR")
         return 0
 


### PR DESCRIPTION
## Summary
- Stream VanitySearch stdout directly into RollingAtomicWriter
- Rotate files continuously instead of writing once at termination

## Testing
- `python -m py_compile core/vanity_runner.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61ba1ee3c8327a192c51a05130bb0