### PR TITLE
Fix vanity search binary and output path issues

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -28,7 +28,7 @@ UNIQUE_DIR = os.path.join(DOWNLOADS_DIR, "unique")
 # Where matches and encrypted alerts are archived
 MATCHES_DIR = os.path.join(BASE_DIR, "matches")
 # VanitySearch text outputs
-VANITY_TXT_DIR = os.path.join(BASE_DIR, "output", "vanity_txt")
+VANITY_TXT_DIR = os.path.join(BASE_DIR, "vanity_output")
 VANITY_OUTPUT_DIR = VANITY_TXT_DIR  # legacy alias
 # Local audio clips for alerts
 SOUND_CLIPS_DIR = os.path.join(BASE_DIR, "alerts", "sounds")
@@ -73,8 +73,8 @@ BTC_MIN_FILE_AGE_SEC = 2.0            # ignore files newer than this
 # --- VanitySearch Settings ---
 VANITY_PATTERN = "1**"  # Change this pattern to match your target (e.g., starts with 1)
 # Single VanitySearch binary (CUDA only)
-VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", "vanitysearch.exe")
-VANITYSEARCH_EXE_NAME = "vanitysearch.exe"
+VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", "VanitySearch.exe")
+VANITYSEARCH_EXE_NAME = "VanitySearch.exe"
 # OpenCL/AMD variants from Vanitygen++
 OCLVANITYGEN_PATH = os.path.join(BASE_DIR, "bin", "oclvanitygen.exe")
 OCLVANITYMINER_PATH = os.path.join(BASE_DIR, "bin", "oclvanityminer.exe")

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -278,9 +278,8 @@ def run_vanitysearch_stream(initial_seed_int, batch_id, index_within_batch, paus
         inc_m("keys_generated_lifetime", lines)
 
         try:
-            from core.dashboard import update_dashboard_stat, get_metric as get_m
-            update_dashboard_stat("keys_generated_today", get_m("keys_generated_today"))
-            update_dashboard_stat("keys_generated_lifetime", get_m("keys_generated_lifetime"))
+            update_dashboard_stat("keys_generated_today", get_metric("keys_generated_today"))
+            update_dashboard_stat("keys_generated_lifetime", get_metric("keys_generated_lifetime"))
         except Exception:
             pass
 

--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -263,9 +263,13 @@ def _which(p: str) -> Optional[str]:
 def _resolve_exe() -> Optional[str]:
     bin_dir = _bin_dir()
     for cand in (
+        os.path.join(bin_dir, "VanitySearch.exe"),
         os.path.join(bin_dir, "vanitysearch.exe"),
+        os.path.join(bin_dir, "VanitySearch_cuda.exe"),
         os.path.join(bin_dir, "vanitysearch_cuda.exe"),
+        "VanitySearch.exe",
         "vanitysearch.exe",
+        "VanitySearch_cuda.exe",
         "vanitysearch_cuda.exe",
     ):
         path = _which(cand)
@@ -326,7 +330,7 @@ def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) 
     out_dir = ensure_dir(VANITY_TXT_DIR)
     exe = _resolve_exe()
     if not exe:
-        log_message("❌ VanitySearch binary not found (vanitysearch.exe).", "ERROR")
+        log_message("❌ VanitySearch binary not found (VanitySearch.exe).", "ERROR")
         return 0
 
     seed = _normalize_seed(seed_start)


### PR DESCRIPTION
## Summary
- prevent `UnboundLocalError` in `run_vanitysearch_stream` by dropping redundant import of `update_dashboard_stat`
- correct `VANITYSEARCH_PATH` and executable name to match `VanitySearch.exe`
- unify vanity output path to `vanity_output` directory
- allow `core/vanity_runner` to locate `VanitySearch.exe` on case-sensitive systems

## Testing
- `python -m py_compile core/keygen.py config/settings.py core/vanity_runner.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6c5f3966083278ed15089d484e2c6