### PR TITLE
Handle default metric values when none provided

### DIFF
--- a/core/dashboard.py
+++ b/core/dashboard.py
@@ -548,11 +548,13 @@ def _update_stat_internal(key, value=None):
         return
 
     if value is None:
-        print(
-            f"⚠️ update_dashboard_stat('{key}') called without a value. Defaulting to 'N/A'",
-            flush=True,
-        )
-        value = "N/A"
+        defaults = _default_metrics()
+        value = defaults.get(key, "N/A")
+        if key not in defaults:
+            print(
+                f"⚠️ update_dashboard_stat('{key}') called without a value. Defaulting to '{value}'",
+                flush=True,
+            )
 
     # Support dotted keys for nested dict updates
     if isinstance(key, str) and "." in key:


### PR DESCRIPTION
## Summary
- Avoid warnings for known metrics missing values by defaulting to predefined metrics in `_update_stat_internal`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace43718848327b347418b0d7450d1