### PR TITLE
Fix hang in BTC-only mode by starting logger

### DIFF
--- a/main.py
+++ b/main.py
@@ -414,8 +414,13 @@ def run_only_mode(args):
 
     if getattr(args, "only", None) == "btc":
         compressed = resolve_btc_compression(args)
+        os.makedirs(LOG_DIR, exist_ok=True)
+        start_listener()
         from core.keygen import run_btc_only  # call into keygen module
-        return run_btc_only(compressed=compressed)
+        try:
+            return run_btc_only(compressed=compressed)
+        finally:
+            stop_listener()
 
     return None
 


### PR DESCRIPTION
## Summary
- start logging listener when running `--only btc`
- ensure log directory exists and cleanly stop listener on exit

## Testing
- `pip install -r requirements.txt` *(fails: OSError could not get source code)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad7bbb8ea483278581ec49f320849b