### PR TITLE
Ensure GPU prompt and dashboard in BTC-only mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -416,6 +416,24 @@ def run_only_mode(args):
         compressed = resolve_btc_compression(args)
         os.makedirs(LOG_DIR, exist_ok=True)
         start_listener()
+
+        # Even in BTC-only mode we want to give the user a chance to pick
+        # which GPU should handle VanitySearch.  Previously this mode skipped
+        # the interactive assignment entirely which caused confusion when the
+        # key generator silently defaulted to the first device.  Prompting here
+        # mirrors the behaviour of the full application and ensures the
+        # ``gpu_assignments.json`` file is always created.
+        from core.gpu_selector import assign_gpu_roles
+        assign_gpu_roles()
+
+        # Launch the dashboard UI unless explicitly disabled.  Because the
+        # BTC-only flow blocks while running the key generator, the GUI is
+        # started on a background thread so the main thread can continue with
+        # key generation.
+        if ENABLE_DASHBOARD and not getattr(args, "no_dashboard", False) and not getattr(args, "headless", False):
+            from ui.dashboard_gui import start_dashboard
+            threading.Thread(target=start_dashboard, daemon=True).start()
+
         from core.keygen import run_btc_only  # call into keygen module
         try:
             return run_btc_only(compressed=compressed)

--- a/tests/test_cli_btc_only.py
+++ b/tests/test_cli_btc_only.py
@@ -48,6 +48,7 @@ def _make_args(**kwargs):
         addr_format='compressed',
         skip_downloads=False,
         no_dashboard=False,
+        headless=False,
         enable_bc1=False,
         all=False,
         funded=False,


### PR DESCRIPTION
## Summary
- ask for GPU assignment even when running with `--only btc`
- spawn the dashboard GUI alongside BTC-only keygen
- extend CLI tests to handle `headless` flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad839b91848327bc338bbf4974f958