### PR TITLE
Fix BTC-only flow metrics and vanity checker

### DIFF
--- a/core/btc_only_checker.py
+++ b/core/btc_only_checker.py
@@ -334,3 +334,52 @@ def get_vanity_backlog_count() -> int:
         and f not in PROCESSED_VANITY
     ])
 
+
+def btc_only_checker_loop(
+    shared_metrics=None,
+    shutdown_event=None,
+    pause_event=None,
+    log_q=None,
+    use_all: bool = False,
+    skip_downloads: bool = False,
+) -> None:
+    """Continuously process VanitySearch outputs in BTC-only mode.
+
+    This wrapper initialises shared metrics and periodically invokes
+    :func:`process_pending_vanity_outputs_once` so the GUI can display
+    progress in the simplified ``--only btc`` flow.
+    """
+
+    from core.logger import initialize_logging
+    from core.worker_bootstrap import ensure_metrics_ready, _safe_set_metric
+    from core.dashboard import register_control_events, set_thread_health
+
+    initialize_logging(log_q)
+
+    try:
+        ensure_metrics_ready(shared_metrics)
+        register_control_events(shutdown_event, pause_event, module="btc_check")
+        _safe_set_metric("status.btc_check", "Running")
+        set_thread_health("btc_check", True)
+    except Exception as e:
+        logger.exception(f"btc_only_checker_loop init failed: {e}")
+
+    prepare_btc_only_mode(use_all, logger, skip_downloads=skip_downloads)
+
+    while not (shutdown_event and shutdown_event.is_set()):
+        if pause_event and pause_event.is_set():
+            time.sleep(1)
+            continue
+        try:
+            process_pending_vanity_outputs_once(logger)
+            set_metric("vanity_backlog_count", get_vanity_backlog_count())
+        except Exception as e:
+            logger.warning(f"btc_only_checker_loop tick failed: {e}")
+        time.sleep(1)
+
+    _safe_set_metric("status.btc_check", "Stopped")
+    try:
+        set_thread_health("btc_check", False)
+    except Exception:
+        logger.warning("Failed to update btc_check thread health", exc_info=True)
+

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -55,7 +55,13 @@ logger = get_logger("keygen")
 BTC_COMPRESSED = True
 
 
-def run_btc_only(compressed: bool) -> int:
+def run_btc_only(
+    compressed: bool,
+    shared_metrics=None,
+    shutdown_event=None,
+    pause_event=None,
+    gpu_flag=None,
+) -> int:
     """Run VanitySearch in BTC-only mode.
 
     This launches the standard key generation loop used by the main
@@ -79,8 +85,15 @@ def run_btc_only(compressed: bool) -> int:
 
     try:
         # Re‑use the standard generator loop so behaviour matches the
-        # full application, but avoid spawning extra processes.
-        start_keygen_loop()
+        # full application, but avoid spawning extra processes.  Forward
+        # any supplied shared ``multiprocessing`` primitives so the GUI can
+        # control and observe the loop just like in the full application.
+        start_keygen_loop(
+            shared_metrics=shared_metrics,
+            shutdown_event=shutdown_event,
+            pause_event=pause_event,
+            gpu_flag=gpu_flag,
+        )
     except Exception:
         logger.exception("BTC-only keygen terminated due to an unexpected error")
         return 1

--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ from core.logger import log_message, start_listener, stop_listener, get_logger
 from core.checkpoint import load_keygen_checkpoint, save_keygen_checkpoint
 from core.downloader import download_and_compare_address_lists, generate_test_csv
 from core.csv_checker import check_csvs_day_one, check_csvs
+from core.btc_only_checker import btc_only_checker_loop
 from core.alerts import trigger_startup_alerts, alert_match
 from core.dashboard import (
     update_dashboard_stat,
@@ -426,6 +427,31 @@ def run_only_mode(args):
         from core.gpu_selector import assign_gpu_roles
         assign_gpu_roles()
 
+        shared_metrics = init_dashboard_manager()
+        shutdown_keygen = multiprocessing.Event()
+        pause_keygen = multiprocessing.Event()
+        shutdown_btc = multiprocessing.Event()
+        pause_btc = multiprocessing.Event()
+        vanity_gpu_flag = multiprocessing.Value('i', 1)
+
+        processes = []
+        from core.logger import log_queue
+
+        # Background metrics collector so the GUI has real-time stats
+        p = Process(target=metrics_updater, args=(shared_metrics,))
+        p.daemon = True
+        p.start()
+        processes.append(p)
+
+        # BTC-only vanity output checker
+        p = Process(
+            target=btc_only_checker_loop,
+            args=(shared_metrics, shutdown_btc, pause_btc, log_queue, args.all, args.skip_downloads),
+        )
+        p.daemon = True
+        p.start()
+        processes.append(p)
+
         # Launch the dashboard UI unless explicitly disabled.  Because the
         # BTC-only flow blocks while running the key generator, the GUI is
         # started on a background thread so the main thread can continue with
@@ -436,8 +462,20 @@ def run_only_mode(args):
 
         from core.keygen import run_btc_only  # call into keygen module
         try:
-            return run_btc_only(compressed=compressed)
+            return run_btc_only(
+                compressed=compressed,
+                shared_metrics=shared_metrics,
+                shutdown_event=shutdown_keygen,
+                pause_event=pause_keygen,
+                gpu_flag=vanity_gpu_flag,
+            )
         finally:
+            shutdown_keygen.set()
+            shutdown_btc.set()
+            for proc in processes:
+                if proc.is_alive():
+                    proc.terminate()
+                    proc.join()
             stop_listener()
 
     return None

--- a/tests/test_cli_btc_only.py
+++ b/tests/test_cli_btc_only.py
@@ -35,8 +35,10 @@ sys.modules.setdefault(
     ),
 )
 sys.modules.setdefault('core.keygen', types.SimpleNamespace(run_btc_only=lambda *a, **k: None))
+sys.modules.setdefault('core.btc_only_checker', types.SimpleNamespace(btc_only_checker_loop=lambda *a, **k: None))
 
 import main
+main.metrics_updater = lambda *a, **k: None
 
 
 def _make_args(**kwargs):
@@ -61,28 +63,32 @@ def test_btc_only_default_compressed():
     args = _make_args(only='btc')
     with patch('core.keygen.run_btc_only') as run_mock:
         main.run_only_mode(args)
-        run_mock.assert_called_once_with(compressed=True)
+        run_mock.assert_called_once()
+        assert run_mock.call_args.kwargs.get('compressed') is True
 
 
 def test_btc_only_explicit_uncompressed():
     args = _make_args(only='btc', uncompressed=True)
     with patch('core.keygen.run_btc_only') as run_mock:
         main.run_only_mode(args)
-        run_mock.assert_called_once_with(compressed=False)
+        run_mock.assert_called_once()
+        assert run_mock.call_args.kwargs.get('compressed') is False
 
 
 def test_btc_only_addr_format_uncompressed():
     args = _make_args(only='btc', addr_format='uncompressed')
     with patch('core.keygen.run_btc_only') as run_mock:
         main.run_only_mode(args)
-        run_mock.assert_called_once_with(compressed=False)
+        run_mock.assert_called_once()
+        assert run_mock.call_args.kwargs.get('compressed') is False
 
 
 def test_legacy_only_flag_emits_warning(capsys):
     args = _make_args(only_legacy='btc')
     with patch('core.keygen.run_btc_only') as run_mock:
         main.run_only_mode(args)
-        run_mock.assert_called_once_with(compressed=True)
+        run_mock.assert_called_once()
+        assert run_mock.call_args.kwargs.get('compressed') is True
     assert 'deprecated' in capsys.readouterr().err.lower()
 
 


### PR DESCRIPTION
## Summary
- propagate shared metrics/events to `run_btc_only` so GUI controls work
- add a dedicated `btc_only_checker_loop` that processes VanitySearch output and updates metrics
- start metrics updater and BTC checker processes in `--only btc` mode and wire them to the dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae10a6ecf08327970de0f3d1823af0