### PR TITLE
Add HTTP fallback for Loyce address downloads

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -214,7 +214,7 @@ CSV_Checking_Logs = True
 
 # ===================== 🌍 COIN ADDRESS SOURCES ======================
 COIN_DOWNLOAD_URLS = {
-    "btc": "http://addresses.loyce.club/Bitcoin_addresses_LATEST.txt.gz",
+    "btc": "https://addresses.loyce.club/Bitcoin_addresses_LATEST.txt.gz",
     "doge": "https://github.com/Pymmdrza/Rich-Address-Wallet/releases/download/Dogecoin/Latest_Dogecoin_Addresses.tsv.gz",
     "ltc": "https://github.com/Pymmdrza/Rich-Address-Wallet/releases/download/Litecoin/Latest_Litecoin_Addresses.tsv.gz",
     "eth": "https://raw.githubusercontent.com/Pymmdrza/Rich-Address-Wallet/refs/heads/main/ETHEREUM/EthRich.txt",

--- a/config/settings.py
+++ b/config/settings.py
@@ -154,7 +154,7 @@ TOKENVIEW_API_KEY = os.getenv("TOKENVIEW_API_KEY", "")
 
 # ===================== 🌍 COIN SOURCES ==========================
 COIN_DOWNLOAD_URLS = {
-    "btc": "http://addresses.loyce.club/Bitcoin_addresses_LATEST.txt.gz",
+    "btc": "https://addresses.loyce.club/Bitcoin_addresses_LATEST.txt.gz",
     "doge": "https://github.com/Pymmdrza/Rich-Address-Wallet/releases/download/Dogecoin/Latest_Dogecoin_Addresses.tsv.gz",
     "ltc": "https://github.com/Pymmdrza/Rich-Address-Wallet/releases/download/Litecoin/Latest_Litecoin_Addresses.tsv.gz",
     "eth": "https://raw.githubusercontent.com/Pymmdrza/Rich-Address-Wallet/refs/heads/main/ETHEREUM/EthRich.txt",

--- a/core/btc_ranges.py
+++ b/core/btc_ranges.py
@@ -2,7 +2,6 @@
 
 import os
 import gzip
-import requests
 from typing import Iterable, List, Tuple
 
 from config.settings import (
@@ -13,13 +12,13 @@ from config.settings import (
     BTC_RANGE_FILE_PATTERN,
 )
 from core.dashboard import set_metric
+from utils.network_utils import get_with_https_fallback
 
 
 def download_with_progress(url: str, dest_path: str, logger) -> None:
     """Stream HTTP download with progress metrics."""
     os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-    r = requests.get(url, stream=True, timeout=30)
-    r.raise_for_status()
+    r = get_with_https_fallback(url, stream=True, timeout=30)
     total = int(r.headers.get("Content-Length", 0))
     if total:
         set_metric("btc_ranges_download_size_bytes", total)

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -4,12 +4,12 @@ import os
 import gzip
 import shutil
 import csv
-import requests
 from datetime import datetime
 from glob import glob
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from utils.file_utils import find_latest_funded_file
+from utils.network_utils import get_with_https_fallback
 
 from config.settings import (
     COIN_DOWNLOAD_URLS,
@@ -152,8 +152,7 @@ def _download_single_coin(coin: str, url: str) -> None:
         )
         gz_path = output_full + ".gz"
 
-        r = requests.get(url, stream=True, timeout=30)
-        r.raise_for_status()
+        r = get_with_https_fallback(url, stream=True, timeout=30)
         with open(gz_path, "wb") as f:
             for chunk in r.iter_content(chunk_size=8192):
                 f.write(chunk)

--- a/utils/network_utils.py
+++ b/utils/network_utils.py
@@ -1,0 +1,24 @@
+import requests
+from urllib.parse import urlparse
+
+from core.logger import log_message
+
+
+def get_with_https_fallback(url: str, **kwargs) -> requests.Response:
+    """Retrieve URL, retrying over HTTP if HTTPS fails for loyce.club hosts."""
+    try:
+        r = requests.get(url, **kwargs)
+        r.raise_for_status()
+        return r
+    except requests.RequestException:
+        parsed = urlparse(url)
+        if parsed.scheme == "https" and parsed.netloc.endswith("loyce.club"):
+            fallback_url = url.replace("https://", "http://", 1)
+            log_message(
+                f"HTTPS request failed for {url}, falling back to {fallback_url}",
+                "WARN",
+            )
+            r = requests.get(fallback_url, **kwargs)
+            r.raise_for_status()
+            return r
+        raise


### PR DESCRIPTION
## Summary
- Use HTTPS for BTC funded address list with automatic HTTP fallback when HTTPS fails
- Add `get_with_https_fallback` helper for Loyce.club downloads
- Apply fallback logic in downloader and BTC range builder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae56c33b148327b3ca4a0a2dc15166