### PR TITLE
Restrict puzzle mode seed generation to puzzle range

### DIFF
--- a/core/keygen.py
+++ b/core/keygen.py
@@ -28,6 +28,7 @@ from config.constants import SECP256K1_ORDER
 from core.checkpoint import load_keygen_checkpoint as load_checkpoint, save_keygen_checkpoint as save_checkpoint
 from core.gpu_selector import get_vanitysearch_gpu_ids  # ✅ Correct GPU selection integration
 from core.logger import get_logger
+import config.settings as settings
 
 
 # Runtime trackers
@@ -134,7 +135,21 @@ def generate_seed_from_batch(batch_id, index_within_batch, batch_size=1024000):
 
 
 def generate_random_seed(min_bits=128):
-    """Generate a cryptographically secure random seed."""
+    """Generate a cryptographically secure random seed.
+
+    When puzzle mode is active, seeds are restricted to the configured
+    puzzle range defined by ``settings.PUZZLE_START`` and
+    ``settings.PUZZLE_END``. Otherwise a random seed in
+    ``[2^min_bits, SECP256K1_ORDER)`` is returned.
+    """
+    if getattr(settings, "PUZZLE_MODE", False):
+        start = int(getattr(settings, "PUZZLE_START", "0"), 16)
+        end = int(getattr(settings, "PUZZLE_END", "0"), 16)
+        if end < start:
+            start, end = end, start
+        span = max(1, end - start + 1)
+        return secrets.randbelow(span) + start
+
     min_val = 1 << min_bits
     range_span = SECP256K1_ORDER - min_val
     return secrets.randbelow(range_span) + min_val

--- a/tests/test_puzzle_utils.py
+++ b/tests/test_puzzle_utils.py
@@ -21,3 +21,52 @@ def test_handle_puzzle_mode_sets_settings(monkeypatch):
     assert getattr(main.settings, "PUZZLE_START") == info["start"]
     assert main.settings.VANITY_PATTERN == info["address"]
     assert args.compressed is True
+
+
+def test_generate_random_seed_respects_puzzle(monkeypatch):
+    info = get_puzzle_info(5)
+    import importlib, sys
+
+    # Tests may stub out ``core.keygen`` in ``sys.modules``; ensure we import the
+    # actual module with minimal stubs for its heavy dependencies.
+    sys.modules.pop("core.keygen", None)
+
+    mod = types.ModuleType("core.gpu_selector")
+    mod.get_vanitysearch_gpu_ids = lambda: []
+    sys.modules["core.gpu_selector"] = mod
+
+    mod = types.ModuleType("core.checkpoint")
+    mod.load_keygen_checkpoint = lambda *a, **k: None
+    mod.save_keygen_checkpoint = lambda *a, **k: None
+    sys.modules["core.checkpoint"] = mod
+
+    mod = types.ModuleType("core.logger")
+    mod.get_logger = lambda *a, **k: types.SimpleNamespace(
+        info=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+        exception=lambda *a, **k: None,
+    )
+    sys.modules["core.logger"] = mod
+
+    mod = types.ModuleType("core.dashboard")
+    mod.init_shared_metrics = lambda *a, **k: None
+    mod.set_metric = lambda *a, **k: None
+    mod.increment_metric = lambda *a, **k: None
+    mod.get_metric = lambda *a, **k: 0
+    mod.register_control_events = lambda *a, **k: None
+    mod.update_dashboard_stat = lambda *a, **k: None
+    sys.modules["core.dashboard"] = mod
+    keygen = importlib.import_module("core.keygen")
+
+    dummy_settings = types.SimpleNamespace(
+        PUZZLE_MODE=True,
+        PUZZLE_START=info["start"],
+        PUZZLE_END=info["end"],
+    )
+    monkeypatch.setattr(keygen, "settings", dummy_settings, raising=False)
+    for _ in range(50):
+        seed = keygen.generate_random_seed()
+        assert int(info["start"], 16) <= seed <= int(info["end"], 16)
+


### PR DESCRIPTION
## Summary
- limit generate_random_seed to puzzle-defined range when puzzle mode is active
- add regression test ensuring seeds fall within puzzle range

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3899f89e483279198a010ae48a863