### PR TITLE
Generalize SQLite queue for all puzzles

### DIFF
--- a/core/keygen.py
+++ b/core/keygen.py
@@ -135,14 +135,21 @@ def generate_seed_from_batch(batch_id, index_within_batch, batch_size=1024000):
 
 
 def generate_random_seed(min_bits=128):
-    """Generate a cryptographically secure random seed.
+    """Generate the next seed for VanitySearch.
 
-    When puzzle mode is active, seeds are restricted to the configured
-    puzzle range defined by ``settings.PUZZLE_START`` and
-    ``settings.PUZZLE_END``. Otherwise a random seed in
-    ``[2^min_bits, SECP256K1_ORDER)`` is returned.
+    Puzzle-71 mode uses deterministic chunking backed by SQLite.
+    Other modes keep the previous random behaviour.
     """
     if getattr(settings, "PUZZLE_MODE", False):
+        puzzle_num = getattr(settings, "PUZZLE_NUMBER", None)
+        if puzzle_num is not None:
+            from core import puzzle_queue as pq  # depends on SQLite
+            chunk_idx = getattr(settings, "PUZZLE_CHUNK_INDEX", None)
+            seed = pq.next_seed(puzzle_num, os.uname().nodename, chunk_idx)
+            if seed is None:
+                raise RuntimeError(f"No remaining puzzle-{puzzle_num} chunks to process")
+            return seed
+        # Fallback to random within start/end if puzzle number is missing
         start = int(getattr(settings, "PUZZLE_START", "0"), 16)
         end = int(getattr(settings, "PUZZLE_END", "0"), 16)
         if end < start:
@@ -276,7 +283,10 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
     register_control_events(shutdown_event, pause_event, module="keygen")
     if not os.path.exists(VANITY_OUTPUT_DIR):
         os.makedirs(VANITY_OUTPUT_DIR)
-
+    if getattr(settings, "PUZZLE_MODE", False) and getattr(settings, "PUZZLE_NUMBER", None) is not None:
+        # Prepare SQLite queue with deterministic ranges
+        from core import puzzle_queue as pq
+        pq.init_work_queue()
     checkpoint = load_checkpoint()
     if checkpoint:
         KEYGEN_STATE["batch_id"] = checkpoint.get("batch_id", 0)

--- a/core/puzzle_queue.py
+++ b/core/puzzle_queue.py
@@ -1,0 +1,199 @@
+"""
+Generic chunk manager for Bitcoin puzzle ranges.
+Claims non-overlapping key ranges and records per-worker progress.
+"""
+import os
+import sqlite3
+import json
+import time
+from typing import Optional, Tuple
+
+from config.settings import LOG_DIR
+from core.logger import get_logger
+from utils.puzzle import get_puzzle_info
+
+logger = get_logger(__name__)
+
+DB_PATH = os.path.join(LOG_DIR, "work_queue.db")
+CHUNK_SIZE = 1 << 20  # ~1M keys
+
+
+def _checkpoint_file(puzzle: int) -> str:
+    return os.path.join(LOG_DIR, f"puzzle{puzzle}_checkpoint.json")
+
+
+def init_work_queue() -> None:
+    """Ensure the work_queue table exists."""
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """CREATE TABLE IF NOT EXISTS work_queue(
+            puzzle      INTEGER,
+            chunk_start TEXT,
+            chunk_end   TEXT,
+            status      TEXT,
+            assignee    TEXT,
+            updated_at  REAL,
+            PRIMARY KEY (puzzle, chunk_start)
+        )"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _get_bounds(puzzle: int) -> Tuple[int, int]:
+    info = get_puzzle_info(puzzle)
+    start = int(info["start"], 16)
+    end = int(info["end"], 16) + 1  # make half-open
+    return start, end
+
+
+def claim_next_chunk(puzzle: int, assignee: str) -> Optional[Tuple[int, int]]:
+    """Atomically claim the next unprocessed chunk for a puzzle."""
+    start_bound, end_bound = _get_bounds(puzzle)
+    width = len(str(end_bound))
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        conn.isolation_level = "EXCLUSIVE"
+        cur = conn.cursor()
+        cur.execute("BEGIN EXCLUSIVE")
+        cur.execute(
+            """SELECT chunk_start, chunk_end
+                       FROM work_queue
+                       WHERE puzzle=? AND status='pending'
+                       ORDER BY chunk_start LIMIT 1""",
+            (puzzle,),
+        )
+        row = cur.fetchone()
+        if not row:
+            cur.execute(
+                "SELECT chunk_end FROM work_queue WHERE puzzle=? ORDER BY chunk_end DESC LIMIT 1",
+                (puzzle,),
+            )
+            last = cur.fetchone()
+            last_end = int(last[0]) if last else None
+            next_start = start_bound if last_end is None else last_end
+            if next_start >= end_bound:
+                return None
+            end = min(next_start + CHUNK_SIZE, end_bound)
+            cur.execute(
+                "INSERT INTO work_queue VALUES (?,?,?,?,?,?)",
+                (
+                    puzzle,
+                    str(next_start).zfill(width),
+                    str(end).zfill(width),
+                    "pending",
+                    None,
+                    time.time(),
+                ),
+            )
+            row = (str(next_start).zfill(width), str(end).zfill(width))
+        cur.execute(
+            """UPDATE work_queue
+                       SET status='claimed', assignee=?, updated_at=?
+                       WHERE puzzle=? AND chunk_start=?""",
+            (assignee, time.time(), puzzle, row[0]),
+        )
+        conn.commit()
+        return int(row[0]), int(row[1])
+    finally:
+        conn.close()
+
+
+def claim_chunk(puzzle: int, chunk_index: int, assignee: str) -> Optional[Tuple[int, int]]:
+    """Claim a specific chunk by index.
+
+    ``chunk_index`` is zero-based within the puzzle's keyspace.
+    Returns ``(start, end)`` of the chunk or ``None`` if unavailable.
+    """
+    start_bound, end_bound = _get_bounds(puzzle)
+    chunk_start = start_bound + chunk_index * CHUNK_SIZE
+    if chunk_start >= end_bound:
+        return None
+    chunk_end = min(chunk_start + CHUNK_SIZE, end_bound)
+    width = len(str(end_bound))
+    key = str(chunk_start).zfill(width)
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        conn.isolation_level = "EXCLUSIVE"
+        cur = conn.cursor()
+        cur.execute("BEGIN EXCLUSIVE")
+        cur.execute(
+            "SELECT status FROM work_queue WHERE puzzle=? AND chunk_start=?",
+            (puzzle, key),
+        )
+        row = cur.fetchone()
+        if row:
+            if row[0] != "pending":
+                return None
+            cur.execute(
+                """UPDATE work_queue
+                           SET status='claimed', assignee=?, updated_at=?
+                           WHERE puzzle=? AND chunk_start=?""",
+                (assignee, time.time(), puzzle, key),
+            )
+        else:
+            cur.execute(
+                "INSERT INTO work_queue VALUES (?,?,?,?,?,?)",
+                (
+                    puzzle,
+                    key,
+                    str(chunk_end).zfill(width),
+                    "claimed",
+                    assignee,
+                    time.time(),
+                ),
+            )
+        conn.commit()
+        return chunk_start, chunk_end
+    finally:
+        conn.close()
+
+def load_checkpoint(puzzle: int) -> dict:
+    """Load worker progress within the current chunk for a puzzle."""
+    path = _checkpoint_file(puzzle)
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    return {}
+
+
+def save_checkpoint(puzzle: int, state: dict) -> None:
+    """Persist worker progress for crash recovery."""
+    state["updated_at"] = time.time()
+    path = _checkpoint_file(puzzle)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(state, fh, indent=4)
+
+
+def next_seed(puzzle: int, assignee: str, chunk_index: Optional[int] = None) -> Optional[int]:
+    """Return the next seed to test for a puzzle.
+
+    If ``chunk_index`` is provided, the worker will claim that specific chunk
+    before generating seeds.
+    """
+    state = load_checkpoint(puzzle)
+    start = state.get("chunk_start")
+    end = state.get("chunk_end")
+    cur = state.get("cursor")
+
+    if chunk_index is not None:
+        desired_start = _get_bounds(puzzle)[0] + chunk_index * CHUNK_SIZE
+        if start != desired_start or cur is None or cur >= end:
+            claim = claim_chunk(puzzle, chunk_index, assignee)
+            if not claim:
+                return None
+            start, end = claim
+            cur = start
+    elif start is None or cur >= end:
+        claim = claim_next_chunk(puzzle, assignee)
+        if not claim:
+            return None  # no more work
+        start, end = claim
+        cur = start
+
+    seed = cur
+    save_checkpoint(puzzle, {"chunk_start": start, "chunk_end": end, "cursor": seed + 1})
+    return seed

--- a/main.py
+++ b/main.py
@@ -438,8 +438,10 @@ def handle_puzzle_mode(args):
     from utils.puzzle import get_puzzle_info
     info = get_puzzle_info(args.puzzle)
     settings.PUZZLE_MODE = True
+    settings.PUZZLE_NUMBER = args.puzzle
     settings.PUZZLE_START = info["start"]
     settings.PUZZLE_END = info["end"]
+    settings.PUZZLE_CHUNK_INDEX = getattr(args, "chunk", None)
     if getattr(args, "every", False):
         settings.VANITY_PATTERN = "1**"
     else:
@@ -645,6 +647,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--only", type=_parse_only, dest="only", help="Restrict to coin flow(s). Comma-separated list.")
     parser.add_argument("-only", type=_parse_only, dest="only_legacy", help=argparse.SUPPRESS)
     parser.add_argument("--puzzle", type=int, help="Run BTC puzzle mode for given puzzle number")
+    parser.add_argument("--chunk", type=int, help="Puzzle mode: claim specific chunk index")
     puzzle_group = parser.add_mutually_exclusive_group()
     puzzle_group.add_argument("--every", action="store_true", help="Puzzle mode: keep generic '1**' prefix")
     puzzle_group.add_argument("--target", action="store_true", help="Puzzle mode: target puzzle address (default)")

--- a/tests/test_cli_btc_only.py
+++ b/tests/test_cli_btc_only.py
@@ -9,6 +9,16 @@ import types
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 sys.modules.setdefault('pyopencl', types.SimpleNamespace(get_platforms=lambda: [], device_type=types.SimpleNamespace(GPU=0)))
 sys.modules.setdefault('core.altcoin_derive', types.SimpleNamespace(start_altcoin_conversion_process=lambda *a, **k: None))
+# Stub optional environment dependencies
+sys.modules.setdefault('dotenv', types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+sys.modules.setdefault(
+    'psutil',
+    types.SimpleNamespace(
+        cpu_percent=lambda: 0,
+        virtual_memory=lambda: types.SimpleNamespace(percent=0, used=0, total=0),
+        disk_usage=lambda p: types.SimpleNamespace(free=0),
+    ),
+)
 # Stub out heavy modules so ``import main`` does not require optional deps
 sys.modules.setdefault('core.checkpoint', types.SimpleNamespace(load_keygen_checkpoint=lambda *a, **k: None,
                                                                save_keygen_checkpoint=lambda *a, **k: None))

--- a/tests/test_puzzle_queue.py
+++ b/tests/test_puzzle_queue.py
@@ -1,0 +1,56 @@
+import importlib
+import sys
+import types
+
+# Stub external dependencies only if missing
+try:  # pragma: no cover - prefer real module if available
+    import dotenv  # noqa: F401
+except Exception:  # pragma: no cover
+    sys.modules["dotenv"] = types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
+
+try:  # pragma: no cover
+    import ecdsa  # noqa: F401
+except Exception:  # pragma: no cover
+    class _DummySigningKey:
+        @staticmethod
+        def from_string(data, curve=None):
+            class _DummySK:
+                def get_verifying_key(self):
+                    class _DummyVK:
+                        def to_string(self):
+                            return b"\x00" * 64
+                    return _DummyVK()
+            return _DummySK()
+
+    sys.modules["ecdsa"] = types.SimpleNamespace(
+        SigningKey=_DummySigningKey, SECP256k1=object()
+    )
+
+try:  # pragma: no cover
+    import base58  # noqa: F401
+except Exception:  # pragma: no cover
+    sys.modules["base58"] = types.SimpleNamespace(b58encode=lambda b: b"1addr")
+
+import config.settings as settings
+
+
+def test_puzzle_queue_sequential(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "LOG_DIR", tmp_path)
+    pq = importlib.reload(importlib.import_module("core.puzzle_queue"))
+    pq.init_work_queue()
+    start = 1 << (76 - 1)
+    seed1 = pq.next_seed(76, "worker1")
+    seed2 = pq.next_seed(76, "worker1")
+    assert seed1 == start
+    assert seed2 == start + 1
+
+
+def test_puzzle_queue_specific_chunk(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "LOG_DIR", tmp_path)
+    pq = importlib.reload(importlib.import_module("core.puzzle_queue"))
+    pq.init_work_queue()
+    start_bound, _ = pq._get_bounds(76)
+    seed1 = pq.next_seed(76, "worker1", chunk_index=5)
+    assert seed1 == start_bound + 5 * pq.CHUNK_SIZE
+    seed2 = pq.next_seed(76, "worker1", chunk_index=5)
+    assert seed2 == seed1 + 1

--- a/tests/test_puzzle_utils.py
+++ b/tests/test_puzzle_utils.py
@@ -1,5 +1,28 @@
 import types
 import argparse
+import sys
+
+# Stub optional environment dependencies and heavy modules
+sys.modules.setdefault('dotenv', types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+sys.modules.setdefault(
+    'psutil',
+    types.SimpleNamespace(
+        cpu_percent=lambda: 0,
+        virtual_memory=lambda: types.SimpleNamespace(percent=0, used=0, total=0),
+        disk_usage=lambda p: types.SimpleNamespace(free=0),
+    ),
+)
+sys.modules.setdefault('pyopencl', types.SimpleNamespace(get_platforms=lambda: [], device_type=types.SimpleNamespace(GPU=0)))
+sys.modules.setdefault('core.altcoin_derive', types.SimpleNamespace(start_altcoin_conversion_process=lambda *a, **k: None))
+sys.modules.setdefault('core.checkpoint', types.SimpleNamespace(load_keygen_checkpoint=lambda *a, **k: None, save_keygen_checkpoint=lambda *a, **k: None))
+sys.modules.setdefault('core.downloader', types.SimpleNamespace(download_and_compare_address_lists=lambda *a, **k: None, generate_test_csv=lambda *a, **k: None))
+sys.modules.setdefault('core.csv_checker', types.SimpleNamespace(check_csvs_day_one=lambda *a, **k: None, check_csvs=lambda *a, **k: None))
+sys.modules.setdefault('core.alerts', types.SimpleNamespace(trigger_startup_alerts=lambda *a, **k: None, alert_match=lambda *a, **k: None))
+sys.modules.setdefault('core.dashboard', types.SimpleNamespace(update_dashboard_stat=lambda *a, **k: None, _default_metrics={}, init_shared_metrics=lambda *a, **k: None, init_dashboard_manager=lambda *a, **k: None, get_current_metrics=lambda *a, **k: {}, get_metric=lambda *a, **k: None, set_metric=lambda *a, **k: None, warn_rate_limited=lambda *a, **k: None))
+sys.modules.setdefault('ui.dashboard_gui', types.SimpleNamespace(start_dashboard=lambda *a, **k: None))
+sys.modules.setdefault('core.gpu_selector', types.SimpleNamespace(assign_gpu_roles=lambda *a, **k: None, get_vanitysearch_gpu_ids=lambda: [], get_altcoin_gpu_ids=lambda: [], get_gpu_assignments=lambda: {}))
+sys.modules.setdefault('core.keygen', types.SimpleNamespace(run_btc_only=lambda *a, **k: None))
+sys.modules.setdefault('core.btc_only_checker', types.SimpleNamespace(btc_only_checker_loop=lambda *a, **k: None))
 
 from utils.puzzle import get_puzzle_info
 import main


### PR DESCRIPTION
## Summary
- Replace puzzle-71 queue with generic `puzzle_queue` that dishes out non-overlapping ranges for any puzzle via SQLite
- Always pull puzzle seeds from the SQLite queue and initialize it at startup
- Add CLI option `--chunk` and queue helpers so workers can claim a specific chunk index
- Add regression tests verifying sequential seeds and explicit chunk selection for puzzle 76

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41d1f4c788327bdf7b86612085520