### PR TITLE
Add multi-coin mnemonic encoders

### DIFF
--- a/keygen/encoders_mnemonic.py
+++ b/keygen/encoders_mnemonic.py
@@ -1,0 +1,90 @@
+"""Coin encoding utilities for mnemonic mode.
+
+This module provides deterministic helpers to convert private keys into
+addresses and WIF/hex representations for the coins supported by
+``mnemonic_mode``.  The functions are intentionally pure – they perform no
+file or network I/O – so they can be reused by both the producer and
+consumer parts of the mnemonic pipeline.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Tuple
+
+import base58
+from ecdsa import SECP256k1, SigningKey
+from eth_hash.auto import keccak
+from eth_utils import to_checksum_address
+
+from .deriv_paths import COIN_INFO
+
+
+# ---------------------------------------------------------------------------
+# Generic helpers
+# ---------------------------------------------------------------------------
+
+
+def privkey_to_pubkey(priv: bytes, compressed: bool = True) -> bytes:
+    """Return the SEC1 encoded public key for ``priv``."""
+    sk = SigningKey.from_string(priv, curve=SECP256k1)
+    vk = sk.get_verifying_key()
+    if compressed:
+        prefix = b"\x02" if vk.pubkey.point.y() % 2 == 0 else b"\x03"
+        return prefix + vk.to_string()[:32]
+    return b"\x04" + vk.to_string()
+
+
+def pubkey_to_p2pkh(pub: bytes, version: int) -> str:
+    """Convert ``pub`` to a base58 P2PKH address with ``version`` byte."""
+    h160 = hashlib.new("ripemd160", hashlib.sha256(pub).digest()).digest()
+    payload = bytes([version]) + h160
+    checksum = hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
+    return base58.b58encode(payload + checksum).decode()
+
+
+def priv_to_wif(priv: bytes, version: int, compressed: bool = True) -> str:
+    """Encode ``priv`` into Wallet Import Format using ``version``."""
+    payload = bytes([version]) + priv + (b"\x01" if compressed else b"")
+    checksum = hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
+    return base58.b58encode(payload + checksum).decode()
+
+
+# ---------------------------------------------------------------------------
+# Coin specific wrappers
+# ---------------------------------------------------------------------------
+
+
+def _p2pkh_coin(priv: bytes, coin: str) -> Tuple[str, str]:
+    """Return ``(address, wif)`` for P2PKH style coins."""
+    info = COIN_INFO[coin]
+    pub = privkey_to_pubkey(priv, True)
+    addr = pubkey_to_p2pkh(pub, info.p2pkh_version)
+    wif = priv_to_wif(priv, info.wif_version, True)
+    return addr, wif
+
+
+def _eth_like(priv: bytes) -> Tuple[str, str]:
+    """Return ``(address, hex_priv)`` for ETH style coins."""
+    sk = SigningKey.from_string(priv, curve=SECP256k1)
+    pub = sk.get_verifying_key().to_string()
+    addr = keccak(pub)[-20:]
+    return to_checksum_address("0x" + addr.hex()), priv.hex()
+
+
+def encode_privkey(coin: str, priv: bytes) -> Tuple[str, str]:
+    """Encode ``priv`` for ``coin`` returning ``(address, wif_or_hex)``."""
+    coin = coin.lower()
+    if coin in {"eth", "pep"}:
+        return _eth_like(priv)
+    return _p2pkh_coin(priv, coin)
+
+
+# Convenience wrappers preserved for backwards compatibility -----------------
+
+
+def priv_to_btc(priv: bytes) -> Tuple[str, str]:
+    return encode_privkey("btc", priv)
+
+
+def priv_to_eth(priv: bytes) -> str:
+    return encode_privkey("eth", priv)[0]

--- a/keygen/mnemonic_mode.py
+++ b/keygen/mnemonic_mode.py
@@ -21,14 +21,12 @@ import struct
 import random
 from typing import Dict, List, Optional
 
-import base58
-from ecdsa import SECP256k1, SigningKey
-from eth_hash.auto import keccak
-from eth_utils import to_checksum_address
+from ecdsa import SECP256k1
 
 from core.vanity_io import RollingAtomicWriter
 from config import settings
-from .deriv_paths import COIN_INFO, SUPPORTED_COINS, resolve_paths
+from .deriv_paths import SUPPORTED_COINS, resolve_paths
+from .encoders_mnemonic import encode_privkey, privkey_to_pubkey
 
 # ---------------------------------------------------------------------------
 # Word list helpers
@@ -108,52 +106,6 @@ def derive_private_key(seed: bytes, path: str) -> bytes:
 
 
 # ---------------------------------------------------------------------------
-# Encoding helpers
-# ---------------------------------------------------------------------------
-
-
-def privkey_to_pubkey(priv: bytes, compressed: bool = True) -> bytes:
-    """Return the SEC1 encoded public key for ``priv``."""
-    sk = SigningKey.from_string(priv, curve=SECP256k1)
-    vk = sk.get_verifying_key()
-    if compressed:
-        prefix = b"\x02" if vk.pubkey.point.y() % 2 == 0 else b"\x03"
-        return prefix + vk.to_string()[:32]
-    else:
-        return b"\x04" + vk.to_string()
-
-
-def pubkey_to_p2pkh(pub: bytes, version: int = 0x00) -> str:
-    """Convert ``pub`` to a base58 P2PKH address."""
-    h160 = hashlib.new("ripemd160", hashlib.sha256(pub).digest()).digest()
-    payload = bytes([version]) + h160
-    checksum = hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
-    return base58.b58encode(payload + checksum).decode()
-
-
-def priv_to_wif(priv: bytes, version: int = 0x80, compressed: bool = True) -> str:
-    """Encode ``priv`` into Wallet Import Format."""
-    payload = bytes([version]) + priv + (b"\x01" if compressed else b"")
-    checksum = hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
-    return base58.b58encode(payload + checksum).decode()
-
-
-def priv_to_btc(priv: bytes) -> tuple[str, str]:
-    info = COIN_INFO["btc"]
-    pub = privkey_to_pubkey(priv)
-    addr = pubkey_to_p2pkh(pub, info.p2pkh_version)
-    wif = priv_to_wif(priv, info.wif_version, True)
-    return addr, wif
-
-
-def priv_to_eth(priv: bytes) -> str:
-    sk = SigningKey.from_string(priv, curve=SECP256k1)
-    pub = sk.get_verifying_key().to_string()
-    addr = keccak(pub)[-20:]
-    return to_checksum_address("0x" + addr.hex())
-
-
-# ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
 
@@ -200,15 +152,7 @@ def run_mnemonic_mode(args) -> None:
 
     for coin in coins:
         priv = derive_private_key(seed, paths[coin])
-        if coin == "btc":
-            addr, wif = priv_to_btc(priv)
-        elif coin == "eth":
-            addr = priv_to_eth(priv)
-            wif = priv.hex()
-        else:
-            # Future coins can plug in proper encoders here
-            addr = priv.hex()
-            wif = priv.hex()
+        addr, wif = encode_privkey(coin, priv)
         line = (
             f"{timestamp} | {mnemonic} | {args.passphrase or '-'} | coin={coin.upper()} | "
             f"path={paths[coin]} | addr={addr} | wif={wif} | funded=0"

--- a/tests/test_mnemonic_mode.py
+++ b/tests/test_mnemonic_mode.py
@@ -37,7 +37,8 @@ sys.modules.setdefault(
 sys.modules.setdefault('core.keygen', types.SimpleNamespace(run_btc_only=lambda *a, **k: None))
 sys.modules.setdefault('core.btc_only_checker', types.SimpleNamespace(btc_only_checker_loop=lambda *a, **k: None))
 
-from keygen.mnemonic_mode import mnemonic_to_seed, priv_to_btc, priv_to_eth
+from keygen.mnemonic_mode import mnemonic_to_seed
+from keygen.encoders_mnemonic import encode_privkey, priv_to_btc, priv_to_eth
 from keygen.deriv_paths import resolve_paths
 import main
 
@@ -61,6 +62,40 @@ def test_btc_address_from_privkey():
 def test_eth_address_from_privkey():
     priv = (1).to_bytes(32, "big")
     assert priv_to_eth(priv) == "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+
+
+def test_additional_coin_encoders():
+    priv = (1).to_bytes(32, "big")
+    vectors = {
+        "ltc": (
+            "LVuDpNCSSj6pQ7t9Pv6d6sUkLKoqDEVUnJ",
+            "T33ydQRKp4FCW5LCLLUB7deioUMoveiwekdwUwyfRDeGZm76aUjV",
+        ),
+        "bch": (
+            "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
+            "KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn",
+        ),
+        "dash": (
+            "XmN7PQYWKn5MJFna5fRYgP6mxT2F7xpekE",
+            "XBHddvWWiMu3nZhhpTXBQWJMmdz5JNKJD85b9fgKAckCT2coW3Y4",
+        ),
+        "doge": (
+            "DFpN6QqFfUm3gKNaxN6tNcab1FArL9cZLE",
+            "QNcdLVw8fHkixm6NNyN6nVwxKek4u7qrioRbQmjxac5TVoTtZuot",
+        ),
+        "pep": (
+            "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+            priv.hex(),
+        ),
+        "rvn": (
+            "RKxTdfmtxtfLDKZBgx6SvNkBtNu9jRYnLh",
+            "KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn",
+        ),
+    }
+    for coin, (addr, wif) in vectors.items():
+        got_addr, got_wif = encode_privkey(coin, priv)
+        assert got_addr == addr
+        assert got_wif == wif
 
 
 def test_resolve_paths_preset_and_override():


### PR DESCRIPTION
## Summary
- factor out coin encoding helpers into new `encoders_mnemonic` module
- support BCH, LTC, DASH, DOGE, PEP and RVN private key encoding
- update mnemonic mode to use new helper and extend tests

## Testing
- `pytest tests/test_mnemonic_mode.py`

------
https://chatgpt.com/codex/tasks/task_e_68b72659ec348327a28fb1e0ee331382