### PR TITLE
Add continuous mnemonic generation with timed file rotation

### DIFF
--- a/core/vanity_io.py
+++ b/core/vanity_io.py
@@ -18,11 +18,30 @@ class RollingAtomicWriter:
         rotate_lines: int,
         max_bytes: int,
         prefix: str = "vanity",
+        rotate_seconds: Optional[int] = None,
     ) -> None:
+        """Create a new rolling writer.
+
+        Parameters
+        ----------
+        directory:
+            Destination directory for output files.
+        rotate_lines:
+            Rotate once this many lines have been written.
+        max_bytes:
+            Rotate once file reaches this size in bytes.
+        prefix:
+            Filename prefix for generated files.
+        rotate_seconds:
+            If provided, rotate the file after this many seconds
+            regardless of line or byte count.
+        """
+
         self.directory = ensure_dir(directory)
         self.rotate_lines = rotate_lines
         self.max_bytes = max_bytes
         self.prefix = prefix
+        self.rotate_seconds = rotate_seconds
         self._counter = 0
         # Open files in binary mode so byte counting matches on all platforms
         self._fh: Optional[BinaryIO] = None
@@ -45,6 +64,7 @@ class RollingAtomicWriter:
         self._fh = open(self.temp_path, "wb")
         self._lines = 0
         self._bytes = 0
+        self._opened = time.time()
 
     def _commit(self) -> None:
         if not self._fh:
@@ -64,7 +84,14 @@ class RollingAtomicWriter:
         self._fh.write(data)
         self._lines += 1
         self._bytes += len(data)
-        rotated = self._lines >= self.rotate_lines or self._bytes >= self.max_bytes
+        rotated = (
+            self._lines >= self.rotate_lines
+            or self._bytes >= self.max_bytes
+            or (
+                self.rotate_seconds is not None
+                and (time.time() - self._opened) >= self.rotate_seconds
+            )
+        )
         if rotated:
             self._commit()
             self._open_new_file()

--- a/keygen/mnemonic_mode.py
+++ b/keygen/mnemonic_mode.py
@@ -183,6 +183,7 @@ def run_mnemonic_mode(args) -> None:
         rotate_lines=settings.VANITY_ROTATE_LINES,
         max_bytes=settings.VANITY_MAX_BYTES,
         prefix="mnemonic_output",
+        rotate_seconds=60,
     )
 
     # Load funded address data if requested.  Missing files simply yield empty
@@ -193,23 +194,31 @@ def run_mnemonic_mode(args) -> None:
     # device is requested and at least one OpenCL device is present.
     gpu_devices = available_devices()
 
-    mnemonic = generate_mnemonic(num_words, wordlist, rng)
-    if gpu_devices and getattr(args, "gpu_id", None) is not None:
-        seed = pbkdf2_sha512(mnemonic, args.passphrase, device_id=args.gpu_id)
-    else:
-        seed = mnemonic_to_seed(mnemonic, args.passphrase)
-    timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
+    iterations = getattr(args, "iterations", 0) or 0
+    produced = 0
+    try:
+        while iterations <= 0 or produced < iterations:
+            mnemonic = generate_mnemonic(num_words, wordlist, rng)
+            if gpu_devices and getattr(args, "gpu_id", None) is not None:
+                seed = pbkdf2_sha512(mnemonic, args.passphrase, device_id=args.gpu_id)
+            else:
+                seed = mnemonic_to_seed(mnemonic, args.passphrase)
+            timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
 
-    for coin in coins:
-        priv = derive_private_key(seed, paths[coin])
-        addr, wif = encode_privkey(coin, priv)
-        normalized = addr.lower() if coin == "eth" else addr
-        funded_flag = 1 if normalized in funded_sets.get(coin, set()) else 0
-        line = (
-            f"{timestamp} | {mnemonic} | {args.passphrase or '-'} | coin={coin.upper()} | "
-            f"path={paths[coin]} | addr={addr} | wif={wif} | funded={funded_flag}"
-        )
-        writer.write_line(line)
-    writer.close()
+            for coin in coins:
+                priv = derive_private_key(seed, paths[coin])
+                addr, wif = encode_privkey(coin, priv)
+                normalized = addr.lower() if coin == "eth" else addr
+                funded_flag = 1 if normalized in funded_sets.get(coin, set()) else 0
+                line = (
+                    f"{timestamp} | {mnemonic} | {args.passphrase or '-'} | coin={coin.upper()} | "
+                    f"path={paths[coin]} | addr={addr} | wif={wif} | funded={funded_flag}"
+                )
+                writer.write_line(line)
 
-    print(f"Generated mnemonic written to {writer.final_path}")
+            produced += 1
+    except KeyboardInterrupt:
+        pass
+    finally:
+        writer.close()
+        print(f"Generated mnemonics written to {writer.final_path}")

--- a/tests/test_mnemonic_mode.py
+++ b/tests/test_mnemonic_mode.py
@@ -175,6 +175,7 @@ def test_run_mnemonic_mode_marks_funded(tmp_path, monkeypatch):
         funded=True,
         gpu_id=None,
         threads=1,
+        iterations=1,
     )
 
     run_mnemonic_mode(args)

--- a/tests/test_vanity_io.py
+++ b/tests/test_vanity_io.py
@@ -1,0 +1,22 @@
+import time
+from pathlib import Path
+from core.vanity_io import RollingAtomicWriter
+
+
+def test_time_based_rotation(tmp_path):
+    writer = RollingAtomicWriter(
+        str(tmp_path),
+        rotate_lines=1000,
+        max_bytes=10**9,
+        prefix="test",
+        rotate_seconds=1,
+    )
+    writer.write_line("first")
+    first_path = Path(writer.final_path)
+    time.sleep(1.1)
+    writer.write_line("second")
+    second_path = Path(writer.final_path)
+    writer.close()
+    assert first_path != second_path
+    assert first_path.exists()
+    assert second_path.exists()


### PR DESCRIPTION
## Summary
- allow `RollingAtomicWriter` to rotate files after a configurable number of seconds
- run mnemonic mode in a loop and rotate output every 60 seconds
- add tests for time-based rotation and update mnemonic mode tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73312f4f083279a86af5d6b915eb2