### PR TITLE
Simplify mnemonic output format

### DIFF
--- a/keygen/mnemonic_mode.py
+++ b/keygen/mnemonic_mode.py
@@ -14,7 +14,7 @@ points for future GPU acceleration and additional coins.
 from __future__ import annotations
 
 import os
-import time
+import sys
 import hashlib
 import hmac
 import struct
@@ -185,6 +185,8 @@ def run_mnemonic_mode(args) -> None:
         prefix="mnemonic_output",
         rotate_seconds=60,
     )
+    # Record the command invocation once at the top of the output file
+    writer.write_line(" ".join(sys.argv))
 
     # Load funded address data if requested.  Missing files simply yield empty
     # sets so the rest of the pipeline can continue unhindered.
@@ -203,18 +205,20 @@ def run_mnemonic_mode(args) -> None:
                 seed = pbkdf2_sha512(mnemonic, args.passphrase, device_id=args.gpu_id)
             else:
                 seed = mnemonic_to_seed(mnemonic, args.passphrase)
-            timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
 
+            writer.write_line(mnemonic)
+            addr_lines = []
             for coin in coins:
                 priv = derive_private_key(seed, paths[coin])
-                addr, wif = encode_privkey(coin, priv)
+                addr, _ = encode_privkey(coin, priv)
                 normalized = addr.lower() if coin == "eth" else addr
-                funded_flag = 1 if normalized in funded_sets.get(coin, set()) else 0
-                line = (
-                    f"{timestamp} | {mnemonic} | {args.passphrase or '-'} | coin={coin.upper()} | "
-                    f"path={paths[coin]} | addr={addr} | wif={wif} | funded={funded_flag}"
-                )
+                funded_flag = normalized in funded_sets.get(coin, set())
+                line = f"{coin}: {addr}" + (" funded" if funded_flag else "")
+                addr_lines.append(line)
+
+            for line in addr_lines:
                 writer.write_line(line)
+            writer.write_line("")
 
             produced += 1
     except KeyboardInterrupt:

--- a/tests/test_mnemonic_mode.py
+++ b/tests/test_mnemonic_mode.py
@@ -183,4 +183,4 @@ def test_run_mnemonic_mode_marks_funded(tmp_path, monkeypatch):
     output_files = list(tmp_path.glob("mnemonic_output_*.txt"))
     assert len(output_files) == 1
     contents = output_files[0].read_text()
-    assert "funded=1" in contents
+    assert f"btc: {addr} funded" in contents


### PR DESCRIPTION
## Summary
- Reduce I/O by writing mnemonics once followed by coin-address lines
- Prepend command invocation to mnemonic output files
- Update tests for new minimal output format

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b79eab61388327a451d0bbabaeba27