### PR TITLE
Add bc1 address selection and AMD oclvanitygen support

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -677,7 +677,7 @@ BUTTONS_ENABLED = {
 # ===================== 🖥️ GPU/CPU BACKENDS ==========================
 # GPU/CPU selection & binaries
 # Only the CUDA-enabled VanitySearch binary is bundled.
-GPU_BACKEND = "cuda"        # CUDA is the only supported backend
+GPU_BACKEND = os.getenv("GPU_BACKEND", "cuda")  # cuda, opencl, cpu, auto, or oclvanitygen
 VANITYSEARCH_BIN_CUDA = VANITYSEARCH_PATH
 VANITYSEARCH_BIN_OPENCL = ""  # placeholder for future OpenCL support
 VANITYSEARCH_BIN_CPU = VANITYSEARCH_PATH  # CPU fallback shares the same binary

--- a/core/oclvanity_runner.py
+++ b/core/oclvanity_runner.py
@@ -1,0 +1,78 @@
+import os
+import re
+import subprocess
+import time
+from typing import Optional
+
+from config.settings import (
+    OCLVANITYGEN_PATH,
+    MAX_OUTPUT_FILE_SIZE,
+)
+from core.logger import get_logger
+from core.dashboard import update_dashboard_stat
+from core.utils.io_safety import atomic_open, atomic_commit
+
+logger = get_logger(__name__)
+
+
+def run_oclvanitygen(pattern: str, output_path: str, timeout: int = 60, pause_event=None, addr_mode: str = "p2pkh") -> bool:
+    """Execute oclvanitygen with basic output parsing and atomic writes."""
+    if pause_event and pause_event.is_set():
+        logger.info("Keygen paused; skipping OCLVanityGen job")
+        return False
+
+    cmd = [OCLVANITYGEN_PATH, pattern]
+    update_dashboard_stat("vanitysearch_addr_mode", addr_mode)
+    logger.info(f"Executing: {' '.join(cmd)}")
+
+    tmp_path, tmp_handle = atomic_open(output_path)
+    buffer = []
+    valid_lines = 0
+    addr_re = re.compile(
+        r"^(?:PubAddr|PubAddress)\s*:\s*(\S+)|"
+        r"^(1[1-9A-HJ-NP-Za-km-z]{25,34}|3[1-9A-HJ-NP-Za-km-z]{25,34}|bc1[0-9ac-hj-np-z]{11,71})$",
+        re.IGNORECASE,
+    )
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        start = time.time()
+        for line in proc.stdout:
+            buffer.append(line)
+            if addr_re.match(line.strip()):
+                valid_lines += 1
+                if valid_lines == 1:
+                    tmp_handle.writelines(buffer)
+                else:
+                    tmp_handle.write(line)
+            elif valid_lines > 0:
+                tmp_handle.write(line)
+
+            if pause_event and pause_event.is_set():
+                proc.terminate()
+            if timeout and time.time() - start > timeout:
+                proc.terminate()
+            if os.path.exists(tmp_path) and os.path.getsize(tmp_path) >= MAX_OUTPUT_FILE_SIZE:
+                proc.terminate()
+        proc.wait()
+    except Exception:
+        logger.exception("Failed to execute OCLVanityGen")
+        tmp_handle.close()
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        return False
+
+    tmp_handle.close()
+    if valid_lines == 0:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        logger.info(f"No address lines emitted by OCLVanityGen for {addr_mode}")
+        return False
+
+    atomic_commit(tmp_path, output_path)
+    return True

--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -14,6 +14,7 @@ from config.settings import (
     VANITYSEARCH_BIN_CPU,
     MIN_EXPECTED_GPU_MKEYS,
     MAX_OUTPUT_FILE_SIZE,
+    ENABLE_P2PKH,
     ENABLE_P2WPKH,
     ENABLE_TAPROOT,
     DEFAULT_BTC_PATTERNS,
@@ -24,11 +25,13 @@ from config.settings import (
     VANITY_MAX_BYTES,
     ENABLE_BC1_DEFAULT,
     VANITY_MODE,
+    OCLVANITYGEN_PATH,
 )
 from core.logger import get_logger, log_message
 from core.dashboard import set_metric, update_dashboard_stat
 from core.utils.io_safety import atomic_open, atomic_commit
 from core.vanity_io import RollingAtomicWriter, ensure_dir
+from core.oclvanity_runner import run_oclvanitygen
 
 logger = get_logger(__name__)
 logger.info("Atomic writes enabled for vanity outputs (temp → rename). Empty outputs are skipped.")
@@ -86,6 +89,8 @@ def resolve_vanitysearch_binary(backend: str) -> str:
         return VANITYSEARCH_BIN_CUDA
     if backend == "opencl":
         return VANITYSEARCH_BIN_OPENCL
+    if backend == "oclvanitygen":
+        return OCLVANITYGEN_PATH
     return VANITYSEARCH_BIN_CPU
 
 
@@ -93,24 +98,28 @@ def probe_device() -> Tuple[str, Optional[int], str, str]:
     """Select appropriate backend/device based on settings and availability."""
     global _SELECTED_BACKEND, _SELECTED_DEVICE_ID, _SELECTED_DEVICE_NAME, _SELECTED_BINARY
 
-    devices = list_devices()
     backend = "cpu"
     device_id: Optional[int] = None
     device_name = "CPU"
 
-    if not FORCE_CPU_FALLBACK:
-        if GPU_BACKEND in ("cuda", "opencl") and devices.get(GPU_BACKEND):
-            backend = GPU_BACKEND
-            device_id, device_name = devices[GPU_BACKEND][0]
-        elif GPU_BACKEND == "auto":
-            for cand in ("cuda", "opencl"):
-                if devices.get(cand):
-                    backend = cand
-                    device_id, device_name = devices[cand][0]
-                    break
+    if GPU_BACKEND == "oclvanitygen":
+        backend = "oclvanitygen"
+        device_name = "OCLVanityGen"
+    else:
+        devices = list_devices()
+        if not FORCE_CPU_FALLBACK:
+            if GPU_BACKEND in ("cuda", "opencl") and devices.get(GPU_BACKEND):
+                backend = GPU_BACKEND
+                device_id, device_name = devices[GPU_BACKEND][0]
+            elif GPU_BACKEND == "auto":
+                for cand in ("cuda", "opencl"):
+                    if devices.get(cand):
+                        backend = cand
+                        device_id, device_name = devices[cand][0]
+                        break
 
     binary = resolve_vanitysearch_binary(backend)
-    if backend in ("cuda", "opencl") and not os.path.exists(binary):
+    if backend in ("cuda", "opencl", "oclvanitygen") and not os.path.exists(binary):
         _warn_once("binary_missing", f"GPU backend {backend} selected but binary missing. Falling back to CPU")
         backend = "cpu"
         device_id = None
@@ -146,13 +155,18 @@ def build_vanitysearch_args(hex_seed: str) -> List[Tuple[List[str], str]]:
     """Return a list of argument lists for each enabled address type."""
     jobs: List[Tuple[List[str], str]] = []
 
+    backend = get_selected_backend()
+
     def _job(pattern: str) -> List[str]:
+        if backend == "oclvanitygen":
+            return [pattern]
         args = ["-s", hex_seed]
         _apply_mode_flags(args)
         args.append(pattern)
         return args
 
-    jobs.append((_job(DEFAULT_BTC_PATTERNS[0]), "p2pkh"))
+    if ENABLE_P2PKH:
+        jobs.append((_job(DEFAULT_BTC_PATTERNS[0]), "p2pkh"))
     if ENABLE_P2WPKH:
         jobs.append((_job(DEFAULT_BTC_PATTERNS_BECH32[0]), "p2wpkh"))
     if ENABLE_TAPROOT:
@@ -173,6 +187,10 @@ def run_vanitysearch(
     if pause_event and pause_event.is_set():
         logger.info("Keygen paused; skipping VanitySearch job")
         return False
+
+    if backend == "oclvanitygen":
+        pattern = seed_args[0] if seed_args else DEFAULT_BTC_PATTERNS[0]
+        return run_oclvanitygen(pattern, output_path, timeout=timeout, pause_event=pause_event, addr_mode=addr_mode)
 
     binary = resolve_vanitysearch_binary(backend)
     cmd = [binary] + seed_args

--- a/ui/dashboard_gui.py
+++ b/ui/dashboard_gui.py
@@ -112,26 +112,44 @@ class DashboardGUI:
         addr_frame.grid_columnconfigure(0, weight=1)
         addr_frame.grid_columnconfigure(1, weight=1)
         addr_frame.grid_columnconfigure(2, weight=1)
-        self.p2pkh_var = tk.BooleanVar(value=ENABLE_P2PKH)
-        self.p2wpkh_var = tk.BooleanVar(value=ENABLE_P2WPKH)
-        self.taproot_var = tk.BooleanVar(value=ENABLE_TAPROOT)
-        ttk.Checkbutton(
+
+        initial = 'p2pkh' if ENABLE_P2PKH else ('p2wpkh' if ENABLE_P2WPKH else 'taproot')
+        self.addr_type_var = tk.StringVar(value=initial)
+
+        def _select_addr_type():
+            sel = self.addr_type_var.get()
+            settings.ENABLE_P2PKH = sel == 'p2pkh'
+            settings.ENABLE_P2WPKH = sel == 'p2wpkh'
+            settings.ENABLE_TAPROOT = sel == 'taproot'
+            try:
+                from core.dashboard import module_pause_events
+                ev = module_pause_events.get('keygen')
+                if ev:
+                    ev.set()
+                    self.master.after(500, ev.clear)
+            except Exception:
+                pass
+
+        ttk.Radiobutton(
             addr_frame,
             text="1 (P2PKH)",
-            variable=self.p2pkh_var,
-            command=lambda: setattr(settings, 'ENABLE_P2PKH', self.p2pkh_var.get()),
+            variable=self.addr_type_var,
+            value='p2pkh',
+            command=_select_addr_type,
         ).grid(row=0, column=0, sticky="w")
-        ttk.Checkbutton(
+        ttk.Radiobutton(
             addr_frame,
             text="bc1q (P2WPKH)",
-            variable=self.p2wpkh_var,
-            command=lambda: setattr(settings, 'ENABLE_P2WPKH', self.p2wpkh_var.get()),
+            variable=self.addr_type_var,
+            value='p2wpkh',
+            command=_select_addr_type,
         ).grid(row=0, column=1, sticky="w")
-        ttk.Checkbutton(
+        ttk.Radiobutton(
             addr_frame,
             text="bc1p (Taproot)",
-            variable=self.taproot_var,
-            command=lambda: setattr(settings, 'ENABLE_TAPROOT', self.taproot_var.get()),
+            variable=self.addr_type_var,
+            value='taproot',
+            command=_select_addr_type,
         ).grid(row=0, column=2, sticky="w")
 
         # Metric Panels


### PR DESCRIPTION
## Summary
- allow choosing one BTC address type at a time in GUI
- add OCLVanityGen backend for AMD GPU vanity search
- respect P2PKH toggle when building vanity search jobs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7be4996c88327b9279ae2685fdfe4