### PR TITLE
Track vanity seed ranges and display current seed

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -60,7 +60,8 @@ CSV_MAX_ROWS = 100_000
 
 # ===================== 📊 DASHBOARD SETTINGS =======================
 SHOW_BATCHES_COMPLETED = True # Shows how many batches were created
-SHOW_CURRENT_SEED_INDEX = True # Shows Current Derivation Seed Index 
+SHOW_CURRENT_SEED_INDEX = True # Shows Current Derivation Seed Index
+SHOW_CURRENT_SEED = True # Shows current seed value being processed
 SHOW_KEYS_PER_SEC = True # Shows How Many Keys/Sec Your Generating
 SHOW_AVG_KEYGEN_FILE_TIME = True
 SHOW_AVG_CSV_FILE_CHECK_TIME = True

--- a/config/settings.py
+++ b/config/settings.py
@@ -239,6 +239,7 @@ PEP = ENABLED_COINS["PEP"]
 SHOW_BATCHES_COMPLETED = True
 SHOW_CURRENT_SEED_INDEX = True
 SHOW_CURRENT_SEED_INDEX = True
+SHOW_CURRENT_SEED = True
 SHOW_KEYS_PER_SEC = True
 SHOW_AVG_KEYGEN_FILE_TIME = True
 SHOW_AVG_CSV_FILE_CHECK_TIME = True
@@ -481,6 +482,7 @@ STATS_TO_DISPLAY = {
     "keys_per_sec": SHOW_KEYS_PER_SEC,
     "batches_completed": SHOW_BATCHES_COMPLETED,
     "current_seed_index": SHOW_CURRENT_SEED_INDEX,
+    "current_seed": SHOW_CURRENT_SEED,
     "avg_keygen_time": SHOW_AVG_KEYGEN_FILE_TIME,
     "avg_check_time": SHOW_AVG_CSV_FILE_CHECK_TIME,
     "cpu_usage": SHOW_CPU_USAGE_STATS,
@@ -537,6 +539,7 @@ METRICS_LABEL_MAP = {
     "keys_per_sec": "Keys/sec",
     "batches_completed": "Batches Completed",
     "current_seed_index": "Current Seed Index",
+    "current_seed": "Current Seed",
     "avg_keygen_time": "Avg. Keygen Time",
     "avg_check_time": "Avg. CSV Check Time",
     "cpu_usage": "CPU Usage",

--- a/core/dashboard.py
+++ b/core/dashboard.py
@@ -333,6 +333,7 @@ def _default_metrics():
     return {
         "batches_completed": 0,
         "current_seed_index": 0,
+        "current_seed": "0x0",
         "vanitysearch_speed": "0 MKeys/s",
         "vanitysearch_current_mkeys": 0.0,
         "vanitysearch_backend": "cpu",

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -30,6 +30,7 @@ from core.checkpoint import load_keygen_checkpoint as load_checkpoint, save_keyg
 from core.gpu_selector import get_vanitysearch_gpu_ids  # ✅ Correct GPU selection integration
 from core.logger import get_logger
 import config.settings as settings
+from core.seed_tracker import seed_in_used_range, record_seed_range
 
 
 # Runtime trackers
@@ -136,36 +137,44 @@ def generate_seed_from_batch(batch_id, index_within_batch, batch_size=1024000):
 
 
 def generate_random_seed(min_bits=128):
-    """Generate the next seed for VanitySearch.
+    """Generate the next seed for VanitySearch while avoiding used ranges."""
 
-    Puzzle-71 mode uses deterministic chunking backed by SQLite.
-    Other modes keep the previous random behaviour.
-    """
-    if getattr(settings, "PUZZLE_MODE", False):
-        puzzle_num = getattr(settings, "PUZZLE_NUMBER", None)
-        if puzzle_num is not None:
-            from core import puzzle_queue as pq  # depends on SQLite
-            chunk_idx = getattr(settings, "PUZZLE_CHUNK_INDEX", None)
+    while True:
+        if getattr(settings, "PUZZLE_MODE", False):
+            puzzle_num = getattr(settings, "PUZZLE_NUMBER", None)
+            if puzzle_num is not None:
+                from core import puzzle_queue as pq  # depends on SQLite
+                chunk_idx = getattr(settings, "PUZZLE_CHUNK_INDEX", None)
 
-            # ``os.uname`` is unavailable on some platforms (e.g., Windows).
-            # ``platform.node`` provides a portable host identifier which
-            # replicates the ``nodename`` attribute used previously.
-            host_id = platform.node() if hasattr(platform, "node") else "unknown"
-            seed = pq.next_seed(puzzle_num, host_id, chunk_idx)
-            if seed is None:
-                raise RuntimeError(f"No remaining puzzle-{puzzle_num} chunks to process")
+                # ``os.uname`` is unavailable on some platforms (e.g., Windows).
+                # ``platform.node`` provides a portable host identifier which
+                # replicates the ``nodename`` attribute used previously.
+                host_id = platform.node() if hasattr(platform, "node") else "unknown"
+                seed = pq.next_seed(puzzle_num, host_id, chunk_idx)
+                if seed is None:
+                    raise RuntimeError(
+                        f"No remaining puzzle-{puzzle_num} chunks to process"
+                    )
+                if seed_in_used_range(seed):
+                    continue
+                return seed
+            # Fallback to random within start/end if puzzle number is missing
+            start = int(getattr(settings, "PUZZLE_START", "0"), 16)
+            end = int(getattr(settings, "PUZZLE_END", "0"), 16)
+            if end < start:
+                start, end = end, start
+            span = max(1, end - start + 1)
+            seed = secrets.randbelow(span) + start
+            if seed_in_used_range(seed):
+                continue
             return seed
-        # Fallback to random within start/end if puzzle number is missing
-        start = int(getattr(settings, "PUZZLE_START", "0"), 16)
-        end = int(getattr(settings, "PUZZLE_END", "0"), 16)
-        if end < start:
-            start, end = end, start
-        span = max(1, end - start + 1)
-        return secrets.randbelow(span) + start
 
-    min_val = 1 << min_bits
-    range_span = SECP256K1_ORDER - min_val
-    return secrets.randbelow(range_span) + min_val
+        min_val = 1 << min_bits
+        range_span = SECP256K1_ORDER - min_val
+        seed = secrets.randbelow(range_span) + min_val
+        if seed_in_used_range(seed):
+            continue
+        return seed
 
 
 def run_vanitysearch_stream(initial_seed_int, batch_id, index_within_batch, pause_event=None, gpu_flag=None):
@@ -259,14 +268,32 @@ def run_vanitysearch_stream(initial_seed_int, batch_id, index_within_batch, paus
         try:
             with open(current_output_path, 'r', encoding='utf-8') as f:
                 logger.info(f"Opened {current_output_path} for reading")
-                lines = sum(1 for _ in f)
+                lines = 0
+                first_seed = None
+                last_seed = None
+                for line in f:
+                    if line.startswith("Priv (HEX):"):
+                        hex_val = line.split(":", 1)[1].strip().replace("0x", "")
+                        seed_int = int(hex_val, 16)
+                        if first_seed is None:
+                            first_seed = seed_int
+                        last_seed = seed_int
+                        lines += 1
                 total_keys_generated += lines
                 increment_metric("keys_generated_today", lines)
                 increment_metric("keys_generated_lifetime", lines)
                 from core.dashboard import update_dashboard_stat, get_metric
-                update_dashboard_stat("keys_generated_today", get_metric("keys_generated_today"))
-                update_dashboard_stat("keys_generated_lifetime", get_metric("keys_generated_lifetime"))
-                logger.info(f"📄 File complete: {lines} lines → {current_output_path}")
+                update_dashboard_stat(
+                    "keys_generated_today", get_metric("keys_generated_today")
+                )
+                update_dashboard_stat(
+                    "keys_generated_lifetime", get_metric("keys_generated_lifetime")
+                )
+                if first_seed is not None and last_seed is not None:
+                    record_seed_range(first_seed, last_seed)
+                logger.info(
+                    f"📄 File complete: {lines} lines → {current_output_path}"
+                )
         except Exception as e:
             logger.warning(f"⚠️ Failed to count lines in {current_output_path}: {e}")
         return True
@@ -307,6 +334,7 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
     set_metric("keys_generated_today", 0)
     set_metric("vanity_progress_percent", 0)
     set_metric("current_seed_index", KEYGEN_STATE["index_within_batch"])
+    set_metric("current_seed", KEYGEN_STATE.get("last_seed", "0x0"))
 
     try:
         set_metric("status.keygen", "Running")
@@ -369,6 +397,7 @@ def start_keygen_loop(shared_metrics=None, shutdown_event=None, pause_event=None
 
                 KEYGEN_STATE["index_within_batch"] = index
                 KEYGEN_STATE["last_seed"] = hex(seed)[2:].rjust(64, "0")
+                set_metric("current_seed", KEYGEN_STATE["last_seed"])
                 set_metric("current_seed_index", index)
                 progress = round((index / float(FILES_PER_BATCH)) * 100, 2)
                 set_metric("vanity_progress_percent", progress)

--- a/core/seed_tracker.py
+++ b/core/seed_tracker.py
@@ -1,0 +1,46 @@
+import json
+import os
+from typing import List, Tuple
+
+from config.settings import LOG_DIR
+
+SEED_RANGES_PATH = os.path.join(LOG_DIR, "used_seeds.json")
+
+
+def _load_ranges() -> List[Tuple[int, int]]:
+    if not os.path.exists(SEED_RANGES_PATH):
+        return []
+    try:
+        with open(SEED_RANGES_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        ranges = []
+        for item in data:
+            start = int(item.get("start", 0))
+            end = int(item.get("end", 0))
+            ranges.append((start, end))
+        return ranges
+    except Exception:
+        return []
+
+
+def _save_ranges(ranges: List[Tuple[int, int]]) -> None:
+    os.makedirs(os.path.dirname(SEED_RANGES_PATH), exist_ok=True)
+    data = [{"start": s, "end": e} for s, e in ranges]
+    with open(SEED_RANGES_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def record_seed_range(start: int, end: int) -> None:
+    """Record a processed seed range to the tracking file."""
+    ranges = _load_ranges()
+    ranges.append((int(start), int(end)))
+    _save_ranges(ranges)
+
+
+def seed_in_used_range(seed: int) -> bool:
+    """Return ``True`` if ``seed`` falls within a previously used range."""
+    seed = int(seed)
+    for start, end in _load_ranges():
+        if start <= seed <= end:
+            return True
+    return False

--- a/tests/test_seed_tracker.py
+++ b/tests/test_seed_tracker.py
@@ -1,0 +1,15 @@
+import json
+from core import seed_tracker
+
+
+def test_seed_tracker_roundtrip(tmp_path, monkeypatch):
+    log_path = tmp_path / "ranges.json"
+    monkeypatch.setattr(seed_tracker, "SEED_RANGES_PATH", str(log_path))
+    assert seed_tracker.seed_in_used_range(10) is False
+    seed_tracker.record_seed_range(5, 15)
+    assert seed_tracker.seed_in_used_range(10) is True
+    assert seed_tracker.seed_in_used_range(16) is False
+    # ensure data persisted
+    with open(log_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data == [{"start": 5, "end": 15}]

--- a/ui/dashboard_gui.py
+++ b/ui/dashboard_gui.py
@@ -175,7 +175,7 @@ class DashboardGUI:
             "batches_completed", "avg_keygen_time", "backlog_files_queued",
             "backlog_eta", "backlog_avg_time", "backlog_current_file",
             "keys_per_sec", "keys_generated_today", "keys_generated_lifetime",
-            "current_seed_index", "altcoin_files_converted",
+            "current_seed_index", "current_seed", "altcoin_files_converted",
             "derived_addresses_today", "vanity_backlog_count",
             "btc_only_files_checked_today", "btc_only_matches_found_today",
             "new_btc_ranges_size_bytes", "btc_ranges_progress", "btc_ranges_last_updated",


### PR DESCRIPTION
## Summary
- show current seed on the dashboard
- track start/end seed ranges from vanity output files and avoid reusing them
- add seed range tracker module with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba318694288327be858af5769e9b9e