### PR TITLE
Optimize seed tracking with range merging and queued generation

### DIFF
--- a/core/keygen.py
+++ b/core/keygen.py
@@ -30,7 +30,11 @@ from core.checkpoint import load_keygen_checkpoint as load_checkpoint, save_keyg
 from core.gpu_selector import get_vanitysearch_gpu_ids  # ✅ Correct GPU selection integration
 from core.logger import get_logger
 import config.settings as settings
-from core.seed_tracker import seed_in_used_range, record_seed_range
+from core.seed_tracker import (
+    seed_in_used_range,
+    record_seed_range,
+    get_condensed_ranges,
+)
 
 
 # Runtime trackers
@@ -38,6 +42,10 @@ total_keys_generated = 0
 keygen_start_time = time.time()
 last_output_file = None
 KPS_WINDOW = deque()
+
+# Prefetch queue to reduce I/O when checking used seeds
+_SEED_QUEUE: list[int] = []
+SEED_QUEUE_SIZE = 10
 
 # Used to track current batch progress
 KEYGEN_STATE = {
@@ -139,6 +147,8 @@ def generate_seed_from_batch(batch_id, index_within_batch, batch_size=1024000):
 def generate_random_seed(min_bits=128):
     """Generate the next seed for VanitySearch while avoiding used ranges."""
 
+    global _SEED_QUEUE
+
     while True:
         if getattr(settings, "PUZZLE_MODE", False):
             puzzle_num = getattr(settings, "PUZZLE_NUMBER", None)
@@ -169,12 +179,16 @@ def generate_random_seed(min_bits=128):
                 continue
             return seed
 
+        if _SEED_QUEUE:
+            return _SEED_QUEUE.pop(0)
+
         min_val = 1 << min_bits
         range_span = SECP256K1_ORDER - min_val
-        seed = secrets.randbelow(range_span) + min_val
-        if seed_in_used_range(seed):
+        ranges = get_condensed_ranges()
+        candidates = [secrets.randbelow(range_span) + min_val for _ in range(SEED_QUEUE_SIZE)]
+        if any(seed_in_used_range(c, ranges) for c in candidates):
             continue
-        return seed
+        _SEED_QUEUE.extend(candidates)
 
 
 def run_vanitysearch_stream(initial_seed_int, batch_id, index_within_batch, pause_event=None, gpu_flag=None):

--- a/core/seed_tracker.py
+++ b/core/seed_tracker.py
@@ -1,5 +1,6 @@
 import json
 import os
+from bisect import bisect_left
 from typing import List, Tuple
 
 from config.settings import LOG_DIR
@@ -8,6 +9,7 @@ SEED_RANGES_PATH = os.path.join(LOG_DIR, "used_seeds.json")
 
 
 def _load_ranges() -> List[Tuple[int, int]]:
+    """Load raw ranges from disk without modification."""
     if not os.path.exists(SEED_RANGES_PATH):
         return []
     try:
@@ -30,17 +32,48 @@ def _save_ranges(ranges: List[Tuple[int, int]]) -> None:
         json.dump(data, f)
 
 
-def record_seed_range(start: int, end: int) -> None:
-    """Record a processed seed range to the tracking file."""
-    ranges = _load_ranges()
-    ranges.append((int(start), int(end)))
+def _condense_ranges(ranges: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    """Return sorted, non-overlapping ranges merged where necessary."""
+    if not ranges:
+        return []
+    ranges = sorted((int(s), int(e)) for s, e in ranges)
+    merged = [ranges[0]]
+    for cur_start, cur_end in ranges[1:]:
+        prev_start, prev_end = merged[-1]
+        if cur_start <= prev_end + 1:
+            merged[-1] = (prev_start, max(prev_end, cur_end))
+        else:
+            merged.append((cur_start, cur_end))
+    return merged
+
+
+def condense_seed_log() -> None:
+    """Load, merge and persist the used seed ranges to keep them minimal."""
+    ranges = _condense_ranges(_load_ranges())
     _save_ranges(ranges)
 
 
-def seed_in_used_range(seed: int) -> bool:
+def get_condensed_ranges() -> List[Tuple[int, int]]:
+    """Return the current used seed ranges in condensed form."""
+    return _condense_ranges(_load_ranges())
+
+
+def record_seed_range(start: int, end: int) -> None:
+    """Record a processed seed range, merging with existing ranges."""
+    ranges = _load_ranges()
+    ranges.append((int(start), int(end)))
+    _save_ranges(_condense_ranges(ranges))
+
+
+def seed_in_used_range(seed: int, ranges: List[Tuple[int, int]] | None = None) -> bool:
     """Return ``True`` if ``seed`` falls within a previously used range."""
     seed = int(seed)
-    for start, end in _load_ranges():
-        if start <= seed <= end:
-            return True
+    if ranges is None:
+        ranges = _condense_ranges(_load_ranges())
+    starts = [s for s, _ in ranges]
+    idx = bisect_left(starts, seed)
+    if idx < len(ranges) and ranges[idx][0] <= seed <= ranges[idx][1]:
+        return True
+    if idx > 0 and ranges[idx - 1][0] <= seed <= ranges[idx - 1][1]:
+        return True
     return False

--- a/tests/test_seed_tracker.py
+++ b/tests/test_seed_tracker.py
@@ -5,11 +5,17 @@ from core import seed_tracker
 def test_seed_tracker_roundtrip(tmp_path, monkeypatch):
     log_path = tmp_path / "ranges.json"
     monkeypatch.setattr(seed_tracker, "SEED_RANGES_PATH", str(log_path))
+
     assert seed_tracker.seed_in_used_range(10) is False
     seed_tracker.record_seed_range(5, 15)
-    assert seed_tracker.seed_in_used_range(10) is True
-    assert seed_tracker.seed_in_used_range(16) is False
-    # ensure data persisted
+    seed_tracker.record_seed_range(20, 25)
+    seed_tracker.record_seed_range(15, 20)
+
+    ranges = seed_tracker.get_condensed_ranges()
+    assert ranges == [(5, 25)]
+    assert seed_tracker.seed_in_used_range(10, ranges) is True
+    assert seed_tracker.seed_in_used_range(30, ranges) is False
+
     with open(log_path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    assert data == [{"start": 5, "end": 15}]
+    assert data == [{"start": 5, "end": 25}]


### PR DESCRIPTION
## Summary
- Merge overlapping seed ranges and use binary search for lookups
- Cache seed ranges and batch-generate seeds to cut disk checks
- Expand seed tracker test coverage for range consolidation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba91769c788327be162b0198d75788