### PR TITLE
Handle headless mode and cross-platform VanitySearch

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -34,7 +34,10 @@ USE_CUSTOM_SEEDS = False
 
 # ===================== 🚀 VANITY SEARCH CONFIG ====================
 # Path to the bundled VanitySearch binary (CUDA only)
-VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", "VanitySearch.exe")
+if os.name == "nt":
+    VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", "VanitySearch.exe")
+else:
+    VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", "VanitySearch")
 PATTERN = "1**"  # Only search for addresses starting with '1'
 VANITYSEARCH_GPU_INDEX = [0]  # Default to GPU 0; override at runtime
 USE_CPU_FALLBACK = True

--- a/config/settings.py
+++ b/config/settings.py
@@ -75,8 +75,11 @@ BTC_MIN_FILE_AGE_SEC = 2.0            # ignore files newer than this
 # --- VanitySearch Settings ---
 VANITY_PATTERN = "1**"  # Change this pattern to match your target (e.g., starts with 1)
 # Single VanitySearch binary (CUDA only)
-VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", "VanitySearch.exe")
-VANITYSEARCH_EXE_NAME = "VanitySearch.exe"
+if os.name == "nt":
+    VANITYSEARCH_EXE_NAME = "VanitySearch.exe"
+else:
+    VANITYSEARCH_EXE_NAME = "VanitySearch"
+VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", VANITYSEARCH_EXE_NAME)
 # OpenCL/AMD variants from Vanitygen++
 OCLVANITYGEN_PATH = os.path.join(BASE_DIR, "bin", "oclvanitygen.exe")
 OCLVANITYMINER_PATH = os.path.join(BASE_DIR, "bin", "oclvanityminer.exe")

--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -280,16 +280,29 @@ def _which(p: str) -> Optional[str]:
 
 def _resolve_exe() -> Optional[str]:
     bin_dir = _bin_dir()
-    for cand in (
-        os.path.join(bin_dir, "VanitySearch.exe"),
-        os.path.join(bin_dir, "vanitysearch.exe"),
-        os.path.join(bin_dir, "VanitySearch_cuda.exe"),
-        os.path.join(bin_dir, "vanitysearch_cuda.exe"),
-        "VanitySearch.exe",
-        "vanitysearch.exe",
-        "VanitySearch_cuda.exe",
-        "vanitysearch_cuda.exe",
-    ):
+    if os.name == "nt":
+        candidates = [
+            os.path.join(bin_dir, "VanitySearch.exe"),
+            os.path.join(bin_dir, "vanitysearch.exe"),
+            os.path.join(bin_dir, "VanitySearch_cuda.exe"),
+            os.path.join(bin_dir, "vanitysearch_cuda.exe"),
+            "VanitySearch.exe",
+            "vanitysearch.exe",
+            "VanitySearch_cuda.exe",
+            "vanitysearch_cuda.exe",
+        ]
+    else:
+        candidates = [
+            os.path.join(bin_dir, "VanitySearch"),
+            os.path.join(bin_dir, "vanitysearch"),
+            os.path.join(bin_dir, "VanitySearch_cuda"),
+            os.path.join(bin_dir, "vanitysearch_cuda"),
+            "VanitySearch",
+            "vanitysearch",
+            "VanitySearch_cuda",
+            "vanitysearch_cuda",
+        ]
+    for cand in candidates:
         path = _which(cand)
         if path:
             return path
@@ -348,7 +361,7 @@ def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) 
     out_dir = ensure_dir(VANITY_TXT_DIR)
     exe = _resolve_exe()
     if not exe:
-        log_message("❌ VanitySearch binary not found (VanitySearch.exe).", "ERROR")
+        log_message("❌ VanitySearch binary not found.", "ERROR")
         return 0
 
     seed = _normalize_seed(seed_start)

--- a/main.py
+++ b/main.py
@@ -67,7 +67,6 @@ from core.dashboard import (
     warn_rate_limited,
 )
 import core.dashboard as dashboard_core
-from ui.dashboard_gui import start_dashboard
 from core.gpu_selector import assign_gpu_roles
 from core.altcoin_derive import start_altcoin_conversion_process  # <-- updated import
 
@@ -600,7 +599,8 @@ def run_allinkeys(args):
     threading.Thread(target=monitor, daemon=True).start()
 
     try:
-        if ENABLE_DASHBOARD and not args.no_dashboard:
+        if ENABLE_DASHBOARD and not args.no_dashboard and not getattr(args, "headless", False):
+            from ui.dashboard_gui import start_dashboard
             start_dashboard()
         else:
             while not shutdown_event.is_set():


### PR DESCRIPTION
## Summary
- Load dashboard GUI only when actually needed so headless runs don't require Tk
- Select VanitySearch binary by platform and ignore Windows-only `.exe` on non-Windows systems
- Detect VanitySearch without `.exe` extension in runtime helper and use a generic missing-binary error

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bccf921ba88327947f05bd8e552a76