### PR TITLE
Improve VanitySearch binary resolution and Linux install

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -4,6 +4,7 @@ Auto-merged to restore full functionality.
 """
 
 import os
+import shutil
 from datetime import datetime
 from dotenv import load_dotenv
 
@@ -74,12 +75,45 @@ BTC_MIN_FILE_AGE_SEC = 2.0            # ignore files newer than this
 
 # --- VanitySearch Settings ---
 VANITY_PATTERN = "1**"  # Change this pattern to match your target (e.g., starts with 1)
-# Single VanitySearch binary (CUDA only)
-if os.name == "nt":
-    VANITYSEARCH_EXE_NAME = "VanitySearch.exe"
-else:
-    VANITYSEARCH_EXE_NAME = "VanitySearch"
-VANITYSEARCH_PATH = os.path.join(BASE_DIR, "bin", VANITYSEARCH_EXE_NAME)
+
+
+def find_vanitysearch_binary():
+    """Return the first VanitySearch binary found for the host OS."""
+    bin_dir = os.path.join(BASE_DIR, "bin")
+    if os.name == "nt":
+        candidates = [
+            os.path.join(bin_dir, "VanitySearch.exe"),
+            os.path.join(bin_dir, "vanitysearch.exe"),
+            os.path.join(bin_dir, "VanitySearch_cuda.exe"),
+            os.path.join(bin_dir, "vanitysearch_cuda.exe"),
+            "VanitySearch.exe",
+            "vanitysearch.exe",
+            "VanitySearch_cuda.exe",
+            "vanitysearch_cuda.exe",
+        ]
+    else:
+        candidates = [
+            os.path.join(bin_dir, "VanitySearch"),
+            os.path.join(bin_dir, "vanitysearch"),
+            os.path.join(bin_dir, "VanitySearch_cuda"),
+            os.path.join(bin_dir, "vanitysearch_cuda"),
+            "VanitySearch",
+            "vanitysearch",
+            "VanitySearch_cuda",
+            "vanitysearch_cuda",
+        ]
+    for cand in candidates:
+        if os.path.isabs(cand) and os.path.isfile(cand):
+            return cand
+        found = shutil.which(cand)
+        if found:
+            return found
+        if os.path.isfile(cand):
+            return cand
+    return None
+
+
+VANITYSEARCH_PATH = find_vanitysearch_binary()
 # OpenCL/AMD variants from Vanitygen++
 OCLVANITYGEN_PATH = os.path.join(BASE_DIR, "bin", "oclvanitygen.exe")
 OCLVANITYMINER_PATH = os.path.join(BASE_DIR, "bin", "oclvanityminer.exe")
@@ -684,9 +718,9 @@ BUTTONS_ENABLED = {
 # GPU/CPU selection & binaries
 # Only the CUDA-enabled VanitySearch binary is bundled.
 GPU_BACKEND = os.getenv("GPU_BACKEND", "cuda")  # cuda, opencl, cpu, auto, or oclvanitygen
-VANITYSEARCH_BIN_CUDA = VANITYSEARCH_PATH
+VANITYSEARCH_BIN_CUDA = VANITYSEARCH_PATH or ""
 VANITYSEARCH_BIN_OPENCL = ""  # placeholder for future OpenCL support
-VANITYSEARCH_BIN_CPU = VANITYSEARCH_PATH  # CPU fallback shares the same binary
+VANITYSEARCH_BIN_CPU = VANITYSEARCH_PATH or ""  # CPU fallback shares the same binary
 
 FORCE_CPU_FALLBACK = False  # If True, run CPU even if GPU available
 MIN_EXPECTED_GPU_MKEYS = 120.0  # GTX 1060 typical: 150–230 MKeys/s

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -11,7 +11,6 @@ import platform
 from datetime import datetime
 from collections import deque
 from config.settings import (
-    VANITYSEARCH_PATH,
     VANITY_OUTPUT_DIR,
     VANITY_PATTERN,
     BATCH_SIZE,
@@ -21,8 +20,8 @@ from config.settings import (
     MAX_OUTPUT_FILE_SIZE,
     MAX_OUTPUT_LINES,
     ROTATE_INTERVAL_SECONDS,
-    FILES_PER_BATCH
-
+    FILES_PER_BATCH,
+    find_vanitysearch_binary,
 )
 
 from config.constants import SECP256K1_ORDER
@@ -214,7 +213,11 @@ def run_vanitysearch_stream(initial_seed_int, batch_id, index_within_batch, paus
     )
     last_output_file = current_output_path
 
-    cmd = [VANITYSEARCH_PATH, "-s", hex_seed_full, "-o", current_output_path]
+    exe_path = find_vanitysearch_binary()
+    if not exe_path:
+        logger.error("VanitySearch binary not found.")
+        return False
+    cmd = [exe_path, "-s", hex_seed_full, "-o", current_output_path]
     if use_gpu:
         cmd.append("-gpu")  # Enable CUDA acceleration
     if not BTC_COMPRESSED:

--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -2,7 +2,6 @@ import os
 import re
 import subprocess
 import time
-import shutil
 import tempfile
 from typing import Dict, List, Tuple, Optional
 
@@ -26,6 +25,7 @@ from config.settings import (
     ENABLE_BC1_DEFAULT,
     VANITY_MODE,
     OCLVANITYGEN_PATH,
+    find_vanitysearch_binary,
 )
 from core.logger import get_logger, log_message
 from core.dashboard import set_metric, update_dashboard_stat
@@ -64,7 +64,7 @@ def list_devices() -> Dict[str, List[Tuple[int, str]]]:
         "opencl": VANITYSEARCH_BIN_OPENCL,
     }
     for backend, bin_path in binaries.items():
-        if not os.path.exists(bin_path):
+        if not bin_path or not os.path.exists(bin_path):
             continue
         out = _run_binary(bin_path, ["-l"])
         entries: List[Tuple[int, str]] = []
@@ -80,18 +80,18 @@ def list_devices() -> Dict[str, List[Tuple[int, str]]]:
 _SELECTED_BACKEND: str = "cpu"
 _SELECTED_DEVICE_ID: Optional[int] = None
 _SELECTED_DEVICE_NAME: str = "CPU"
-_SELECTED_BINARY: str = VANITYSEARCH_BIN_CPU
+_SELECTED_BINARY: str = VANITYSEARCH_BIN_CPU or ""
 
 
 def resolve_vanitysearch_binary(backend: str) -> str:
     """Return the VanitySearch binary path for ``backend``."""
     if backend == "cuda":
-        return VANITYSEARCH_BIN_CUDA
+        return VANITYSEARCH_BIN_CUDA or find_vanitysearch_binary()
     if backend == "opencl":
         return VANITYSEARCH_BIN_OPENCL
     if backend == "oclvanitygen":
         return OCLVANITYGEN_PATH
-    return VANITYSEARCH_BIN_CPU
+    return VANITYSEARCH_BIN_CPU or find_vanitysearch_binary()
 
 
 def probe_device() -> Tuple[str, Optional[int], str, str]:
@@ -119,7 +119,9 @@ def probe_device() -> Tuple[str, Optional[int], str, str]:
                         break
 
     binary = resolve_vanitysearch_binary(backend)
-    if backend in ("cuda", "opencl", "oclvanitygen") and not os.path.exists(binary):
+    if backend in ("cuda", "opencl", "oclvanitygen") and (
+        not binary or not os.path.exists(binary)
+    ):
         _warn_once("binary_missing", f"GPU backend {backend} selected but binary missing. Falling back to CPU")
         backend = "cpu"
         device_id = None
@@ -267,46 +269,10 @@ get_selected_device_name = lambda: _SELECTED_DEVICE_NAME
 
 
 # --- New unified generator --------------------------------------------------
-def _bin_dir() -> str:
-    return os.path.join(os.path.dirname(os.path.dirname(__file__)), "bin")
-
-
-def _which(p: str) -> Optional[str]:
-    if os.path.isabs(p) and os.path.isfile(p):
-        return p
-    f = shutil.which(p)
-    return f if f else (p if os.path.isfile(p) else None)
 
 
 def _resolve_exe() -> Optional[str]:
-    bin_dir = _bin_dir()
-    if os.name == "nt":
-        candidates = [
-            os.path.join(bin_dir, "VanitySearch.exe"),
-            os.path.join(bin_dir, "vanitysearch.exe"),
-            os.path.join(bin_dir, "VanitySearch_cuda.exe"),
-            os.path.join(bin_dir, "vanitysearch_cuda.exe"),
-            "VanitySearch.exe",
-            "vanitysearch.exe",
-            "VanitySearch_cuda.exe",
-            "vanitysearch_cuda.exe",
-        ]
-    else:
-        candidates = [
-            os.path.join(bin_dir, "VanitySearch"),
-            os.path.join(bin_dir, "vanitysearch"),
-            os.path.join(bin_dir, "VanitySearch_cuda"),
-            os.path.join(bin_dir, "vanitysearch_cuda"),
-            "VanitySearch",
-            "vanitysearch",
-            "VanitySearch_cuda",
-            "vanitysearch_cuda",
-        ]
-    for cand in candidates:
-        path = _which(cand)
-        if path:
-            return path
-    return None
+    return find_vanitysearch_binary()
 
 
 def _normalize_seed(seed_val: int) -> str:

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import signal
 import argparse
 import multiprocessing
 import threading
+import subprocess
 from datetime import datetime, timedelta
 from multiprocessing import Process
 from core.logger import get_logger
@@ -46,8 +47,9 @@ from config.settings import (
     LOGO_ART, ENABLE_DAY_ONE_CHECK, ENABLE_UNIQUE_RECHECK,
     ENABLE_DASHBOARD, ENABLE_KEYGEN, ENABLE_ALERTS,
     ENABLE_BACKLOG_CONVERSION, LOG_DIR, CONFIG_FILE_PATH,
-    CSV_DIR, VANITYSEARCH_PATH, DOWNLOAD_DIR, VANITY_OUTPUT_DIR,
-    BACKLOG_PAUSE_THRESHOLD, BACKLOG_RESUME_THRESHOLD
+    CSV_DIR, DOWNLOAD_DIR, VANITY_OUTPUT_DIR,
+    BACKLOG_PAUSE_THRESHOLD, BACKLOG_RESUME_THRESHOLD,
+    find_vanitysearch_binary,
 )
 
 from core.logger import log_message, start_listener, stop_listener, get_logger
@@ -736,9 +738,17 @@ if __name__ == "__main__":
     except RuntimeError:
         pass  # already set
 
-    if not os.path.exists(VANITYSEARCH_PATH):
-        raise FileNotFoundError(f"VanitySearch not found at: {VANITYSEARCH_PATH}")
+    vanity_path = find_vanitysearch_binary()
+    if not vanity_path and os.name != "nt":
+        try:
+            subprocess.run(["apt-get", "update"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(["apt-get", "install", "-y", "vanitysearch"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except Exception:
+            pass
+        vanity_path = find_vanitysearch_binary()
+    if not vanity_path:
+        raise FileNotFoundError("VanitySearch binary not found. Please install VanitySearch.")
     else:
-        print(f"✅ VanitySearch found: {VANITYSEARCH_PATH}", flush=True)
+        print(f"✅ VanitySearch found: {vanity_path}", flush=True)
 
     sys.exit(main())


### PR DESCRIPTION
## Summary
- detect VanitySearch executables per host OS, searching for both `.exe` and non-suffixed binaries
- handle missing binaries gracefully in key generation and runner
- on Linux, attempt `apt` install when VanitySearch is missing

## Testing
- `pytest tests/test_mnemonic_mode.py::test_get_random_known_phrase -q` *(fails: No module named 'eth_utils')*


------
https://chatgpt.com/codex/tasks/task_e_68bcd63b6a3483278cf697661dfa3dc9