### PR TITLE
Handle missing pyopencl gracefully

### DIFF
--- a/core/altcoin_derive.py
+++ b/core/altcoin_derive.py
@@ -12,7 +12,10 @@ import os
 import csv
 import hashlib
 import base58
-import pyopencl as cl
+try:
+    import pyopencl as cl
+except Exception:  # pragma: no cover - optional dependency
+    cl = None
 import numpy as np
 from eth_hash.auto import keccak
 from ecdsa import SigningKey, SECP256k1
@@ -257,6 +260,8 @@ def get_gpu_context_for_altcoin():
         )
         selected = [next(iter(available_ids), 0)]
 
+    if cl is None:
+        raise RuntimeError("pyopencl not available")
     try:
         platforms = cl.get_platforms()
         platform_names = [p.name for p in platforms]
@@ -613,11 +618,14 @@ def derive_addresses_cpu(hex_keys):
 
 def derive_addresses(hex_keys, context=None):
     """Try GPU derivation then fall back to CPU on failure."""
+    if cl is None:
+        global cpu_fallback_active
+        cpu_fallback_active = True
+        return derive_addresses_cpu(hex_keys)
     try:
         return derive_addresses_gpu(hex_keys, context)
     except Exception as e:
         log_message(f"⚠️ GPU derive failed, falling back to CPU: {safe_str(e)}", "WARNING")
-        global cpu_fallback_active
         cpu_fallback_active = True
         return derive_addresses_cpu(hex_keys)
 

--- a/core/gpu_selector.py
+++ b/core/gpu_selector.py
@@ -3,7 +3,10 @@
 import os
 import time
 import json
-import pyopencl as cl
+try:
+    import pyopencl as cl
+except Exception:  # pragma: no cover - optional dependency
+    cl = None
 
 try:
     import GPUtil

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ This repository was recently opened to the public and remains a work in progress
 
 * Python 3.9+
 * Git
-* Optional: CUDA/OpenCL drivers for GPU support
+* Optional: CUDA/OpenCL drivers and `pyopencl` for GPU support
 
 ```bash
 git clone https://github.com/mattysparkles/allinkeys.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ pyaudio
 soundfile
 pycryptodome
 py-cpuinfo
-pyopencl
 ecdsa
 eth-hash
 base58
@@ -25,3 +24,4 @@ GPUtil
 eth-account
 python-dotenv
 tzlocal
+# Optional: install pyopencl separately for GPU acceleration


### PR DESCRIPTION
## Summary
- Avoid hard crash if pyopencl is absent by making import optional in `gpu_selector` and `altcoin_derive`
- Fall back to CPU derivation when no OpenCL runtime is available
- Remove `pyopencl` from default requirements and note optional installation in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcd95e5f9083278c3e1ec40654c072