### PR TITLE
Fix VanitySearch binary resolution

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -113,10 +113,36 @@ def find_vanitysearch_binary():
     return None
 
 
+def find_oclvanity_binary(base_name: str):
+    """Return path to ``base_name`` for the host OS."""
+    bin_dir = os.path.join(BASE_DIR, "bin")
+    if os.name == "nt":
+        candidates = [
+            os.path.join(bin_dir, f"{base_name}.exe"),
+            os.path.join(bin_dir, f"{base_name}.EXE"),
+            f"{base_name}.exe",
+            f"{base_name}.EXE",
+        ]
+    else:
+        candidates = [
+            os.path.join(bin_dir, base_name),
+            base_name,
+        ]
+    for cand in candidates:
+        if os.path.isabs(cand) and os.path.isfile(cand):
+            return cand
+        found = shutil.which(cand)
+        if found:
+            return found
+        if os.path.isfile(cand):
+            return cand
+    return None
+
+
 VANITYSEARCH_PATH = find_vanitysearch_binary()
 # OpenCL/AMD variants from Vanitygen++
-OCLVANITYGEN_PATH = os.path.join(BASE_DIR, "bin", "oclvanitygen.exe")
-OCLVANITYMINER_PATH = os.path.join(BASE_DIR, "bin", "oclvanityminer.exe")
+OCLVANITYGEN_PATH = find_oclvanity_binary("oclvanitygen")
+OCLVANITYMINER_PATH = find_oclvanity_binary("oclvanityminer")
 KEYCONV_PATH = os.path.join(BASE_DIR, "bin", "keyconv.exe")
 MAX_KEYS_PER_FILE = 100_000  #Deprecated
 # Output file rotation config (for VanitySearch stream)

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -216,7 +216,7 @@ def run_vanitysearch_stream(initial_seed_int, batch_id, index_within_batch, paus
     exe_path = find_vanitysearch_binary()
     if not exe_path:
         logger.error("VanitySearch binary not found.")
-        return False
+        raise FileNotFoundError("VanitySearch binary not found.")
     cmd = [exe_path, "-s", hex_seed_full, "-o", current_output_path]
     if use_gpu:
         cmd.append("-gpu")  # Enable CUDA acceleration

--- a/core/oclvanity_runner.py
+++ b/core/oclvanity_runner.py
@@ -21,6 +21,9 @@ def run_oclvanitygen(pattern: str, output_path: str, timeout: int = 60, pause_ev
         logger.info("Keygen paused; skipping OCLVanityGen job")
         return False
 
+    if not OCLVANITYGEN_PATH or not os.path.exists(OCLVANITYGEN_PATH):
+        raise FileNotFoundError("OCLVanityGen binary not found.")
+
     cmd = [OCLVANITYGEN_PATH, pattern]
     update_dashboard_stat("vanitysearch_addr_mode", addr_mode)
     logger.info(f"Executing: {' '.join(cmd)}")

--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -84,14 +84,24 @@ _SELECTED_BINARY: str = VANITYSEARCH_BIN_CPU or ""
 
 
 def resolve_vanitysearch_binary(backend: str) -> str:
-    """Return the VanitySearch binary path for ``backend``."""
+    """Return the VanitySearch binary path for ``backend``.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no suitable binary is found for the requested ``backend``.
+    """
     if backend == "cuda":
-        return VANITYSEARCH_BIN_CUDA or find_vanitysearch_binary()
-    if backend == "opencl":
-        return VANITYSEARCH_BIN_OPENCL
-    if backend == "oclvanitygen":
-        return OCLVANITYGEN_PATH
-    return VANITYSEARCH_BIN_CPU or find_vanitysearch_binary()
+        path = VANITYSEARCH_BIN_CUDA or find_vanitysearch_binary()
+    elif backend == "opencl":
+        path = VANITYSEARCH_BIN_OPENCL
+    elif backend == "oclvanitygen":
+        path = OCLVANITYGEN_PATH
+    else:
+        path = VANITYSEARCH_BIN_CPU or find_vanitysearch_binary()
+    if not path or not os.path.exists(path):
+        raise FileNotFoundError("VanitySearch binary not found.")
+    return path
 
 
 def probe_device() -> Tuple[str, Optional[int], str, str]:
@@ -118,7 +128,10 @@ def probe_device() -> Tuple[str, Optional[int], str, str]:
                         device_id, device_name = devices[cand][0]
                         break
 
-    binary = resolve_vanitysearch_binary(backend)
+    try:
+        binary = resolve_vanitysearch_binary(backend)
+    except FileNotFoundError:
+        binary = None
     if backend in ("cuda", "opencl", "oclvanitygen") and (
         not binary or not os.path.exists(binary)
     ):
@@ -126,17 +139,28 @@ def probe_device() -> Tuple[str, Optional[int], str, str]:
         backend = "cpu"
         device_id = None
         device_name = "CPU"
-        binary = resolve_vanitysearch_binary("cpu")
+        try:
+            binary = resolve_vanitysearch_binary("cpu")
+        except FileNotFoundError as e:
+            logger.error(str(e))
+            raise
 
     if backend != "cpu" and FORCE_CPU_FALLBACK:
         _warn_once("cpu_forced", "GPU available but FORCE_CPU_FALLBACK=True; using CPU")
         backend = "cpu"
         device_id = None
         device_name = "CPU"
-        binary = resolve_vanitysearch_binary("cpu")
+        try:
+            binary = resolve_vanitysearch_binary("cpu")
+        except FileNotFoundError as e:
+            logger.error(str(e))
+            raise
 
     if backend == "cpu" and GPU_BACKEND != "cpu":
         _warn_once("cpu_fallback", "GPU backend requested but CPU binary selected")
+
+    if not binary or not os.path.exists(binary):
+        raise FileNotFoundError("VanitySearch binary not found.")
 
     _SELECTED_BACKEND = backend
     _SELECTED_DEVICE_ID = device_id


### PR DESCRIPTION
## Summary
- Detect VanitySearch binaries based on host OS for VanitySearch and oclvanity variants
- Fail fast with a generic error when no VanitySearch executables are present
- Guard oclvanitygen runner and keygen stream against missing binaries

## Testing
- `pip install -r requirements.txt` *(failed: Getting requirements to build wheel: error)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'ecdsa')*

------
https://chatgpt.com/codex/tasks/task_e_68bcdc582884832795121d524270a979