### PR TITLE
feat: add GPU detection and selection

### DIFF
--- a/core/gpu_selector.py
+++ b/core/gpu_selector.py
@@ -26,55 +26,80 @@ SELECTION_TIMEOUT = 20  # seconds
 
 
 def list_gpus():
-    """Return a list of available GPUs with OpenCL device indices."""
+    """Return a list of detected GPU devices.
 
-    gpus = []
-    seen = set()
+    The routine attempts to enumerate both CUDA and OpenCL capable hardware
+    using the optional ``GPUtil`` and ``pyopencl`` libraries.  Each entry in the
+    returned list contains at minimum ``type`` (``nvidia``/``amd``/``other``),
+    ``name`` and a monotonically increasing ``id``.  When an OpenCL index is
+    known it is exposed via ``cl_index``.  A ``backend`` field records whether
+    the device was discovered through the CUDA or OpenCL stack (or both).
 
-    # Enumerate all OpenCL GPU devices so that both AMD and NVIDIA cards
-    # receive a valid ``cl_index`` for later context creation.  Falling back to
-    # GPUtil (if available) ensures we still display devices even if OpenCL is
-    # missing or misconfigured.
-    try:
-        cl_index = 0
-        for platform in cl.get_platforms():
-            for device in platform.get_devices(device_type=cl.device_type.GPU):
-                vendor = device.vendor.lower()
-                if "nvidia" in vendor:
-                    gtype = "nvidia"
-                elif "amd" in vendor or "advanced micro devices" in vendor:
-                    gtype = "amd"
-                else:
-                    gtype = "other"
-                name = device.name.strip()
-                entry = {
-                    "type": gtype,
-                    "name": name,
-                    "id": len(gpus),
-                    "cl_index": cl_index,
-                }
-                gpus.append(entry)
-                seen.add(name)
-                cl_index += 1
-    except Exception:
-        pass
+    Missing libraries or enumeration failures emit warnings but do not raise
+    exceptions so the application can gracefully fall back to CPU execution.
+    """
 
-    # Supplement with GPUtil results (no ``cl_index``) for visibility
-    if GPUtil:
+    gpus: list[dict] = []
+    seen: dict[str, dict] = {}
+
+    # ----------------------------- CUDA detection -----------------------------
+    if GPUtil is None:
+        print("⚠️ GPUtil not available; CUDA devices will not be detected.")
+    else:
         try:
             for gpu in GPUtil.getGPUs():
-                if gpu.name not in seen:
-                    gpus.append(
-                        {
-                            "type": "nvidia",
-                            "name": gpu.name,
+                entry = {
+                    "type": "nvidia",
+                    "name": gpu.name,
+                    "id": len(gpus),
+                    "cl_index": None,
+                    "backend": ["CUDA"],
+                }
+                gpus.append(entry)
+                seen[gpu.name] = entry
+        except Exception as exc:
+            print(f"⚠️ CUDA detection failed: {exc}")
+
+    # ---------------------------- OpenCL detection ----------------------------
+    if cl is None:
+        print("⚠️ PyOpenCL not available; OpenCL devices will not be detected.")
+    else:
+        try:
+            cl_index = 0
+            for platform in cl.get_platforms():
+                for device in platform.get_devices(device_type=cl.device_type.GPU):
+                    vendor = device.vendor.lower()
+                    if "nvidia" in vendor:
+                        gtype = "nvidia"
+                    elif "amd" in vendor or "advanced micro devices" in vendor:
+                        gtype = "amd"
+                    else:
+                        gtype = "other"
+                    name = device.name.strip()
+                    existing = seen.get(name)
+                    if existing:
+                        existing["backend"].append("OpenCL")
+                        existing["cl_index"] = cl_index
+                    else:
+                        entry = {
+                            "type": gtype,
+                            "name": name,
                             "id": len(gpus),
-                            "cl_index": None,
+                            "cl_index": cl_index,
+                            "backend": ["OpenCL"],
                         }
-                    )
-                    seen.add(gpu.name)
-        except Exception:
-            pass
+                        gpus.append(entry)
+                        seen[name] = entry
+                    cl_index += 1
+        except Exception as exc:
+            print(f"⚠️ OpenCL detection failed: {exc}")
+
+    # Normalise backend listing
+    for g in gpus:
+        g["backend"] = "/".join(g.get("backend", []))
+
+    if not gpus:
+        print("⚠️ No CUDA or OpenCL GPUs detected; falling back to CPU.")
 
     return gpus
 
@@ -170,11 +195,35 @@ def prompt_user_to_choose(gpus):
     print("  Altcoin Derive →", ", ".join([g["name"] for g in assigned_gpus["altcoin_derive"]]) or "None")
 
 
-def assign_gpu_roles():
+def assign_gpu_roles(preferred_index: int | None = None):
+    """Populate ``assigned_gpus`` based on detected hardware.
+
+    When ``preferred_index`` is provided the corresponding device is selected
+    for both VanitySearch and Altcoin Derive without prompting the user.  If the
+    index is out of range a warning is emitted and the normal interactive flow
+    is used instead.  When no GPUs are detected the function simply prints a
+    warning and returns, allowing the rest of the application to continue using
+    CPU implementations.
+    """
+
     gpus = list_gpus()
     if not gpus:
         print("⚠️ No GPUs found! Proceeding without GPU acceleration.")
         return
+
+    if preferred_index is not None:
+        if 0 <= preferred_index < len(gpus):
+            assigned_gpus["vanitysearch"] = [gpus[preferred_index]]
+            assigned_gpus["altcoin_derive"] = [gpus[preferred_index]]
+            print(
+                f"🎯 GPU Assignments:\n  VanitySearch → {gpus[preferred_index]['name']}\n  Altcoin Derive → {gpus[preferred_index]['name']}"
+            )
+            save_gpu_assignments()
+            return
+        else:
+            print(
+                f"⚠️ Requested GPU index {preferred_index} out of range; falling back to interactive selection."
+            )
 
     prompt_user_to_choose(gpus)
     save_gpu_assignments()

--- a/main.py
+++ b/main.py
@@ -468,7 +468,7 @@ def run_only_mode(args):
         # mirrors the behaviour of the full application and ensures the
         # ``gpu_assignments.json`` file is always created.
         from core.gpu_selector import assign_gpu_roles
-        assign_gpu_roles()
+        assign_gpu_roles(getattr(args, "gpu_index", None))
 
         shared_metrics = init_dashboard_manager()
         shutdown_keygen = multiprocessing.Event()
@@ -538,7 +538,7 @@ def run_allinkeys(args):
     os.environ.setdefault("PYOPENCL_COMPILER_OUTPUT", "1")
     display_logo()
 
-    assign_gpu_roles()
+    assign_gpu_roles(getattr(args, "gpu_index", None))
     test_csv = os.path.join(DOWNLOAD_DIR, "test_alerts.csv")
     if not os.path.exists(test_csv):
         generate_test_csv()
@@ -650,6 +650,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("-only", type=_parse_only, dest="only_legacy", help=argparse.SUPPRESS)
     parser.add_argument("--puzzle", type=int, help="Run BTC puzzle mode for given puzzle number")
     parser.add_argument("--chunk", type=int, help="Puzzle mode: claim specific chunk index")
+    parser.add_argument("--gpu-index", type=int, help="Force use of a specific GPU device index")
     puzzle_group = parser.add_mutually_exclusive_group()
     puzzle_group.add_argument("--every", action="store_true", help="Puzzle mode: keep generic '1**' prefix")
     puzzle_group.add_argument("--target", action="store_true", help="Puzzle mode: target puzzle address (default)")

--- a/tests/test_cli_btc_only.py
+++ b/tests/test_cli_btc_only.py
@@ -71,6 +71,7 @@ def _make_args(**kwargs):
         puzzle=None,
         every=False,
         target=False,
+        gpu_index=None,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)


### PR DESCRIPTION
## Summary
- detect CUDA and OpenCL hardware with graceful CPU fallback
- allow overriding GPU choice via `--gpu-index` CLI option
- wire CLI selection through to GPU role assignment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd78e698dc8327afd823c648612206