### PR TITLE
Add retry/backoff for process launches

### DIFF
--- a/core/altcoin_derive.py
+++ b/core/altcoin_derive.py
@@ -63,6 +63,7 @@ import core.checkpoint as checkpoint
 from core.gpu_selector import get_altcoin_gpu_ids, list_gpus
 import config.settings as settings
 from core.utils.io_safety import safe_nonempty
+from core.utils.process import start_process_with_retry
 
 
 def safe_str(obj):
@@ -1212,13 +1213,20 @@ def convert_txt_to_csv_loop(shared_shutdown_event, shared_metrics=None, pause_ev
                         name=f"AltcoinWorker-{txt}",
                     )
                     p.daemon = True
-                    p.start()
-                    log_message(
-                        f"Spawned altcoin worker PID {p.pid} for {txt} on GPU {gid if gid is not None else 'CPU'}",
-                        "INFO",
-                    )
-                    processes[gid] = p
-                    queued.add(txt)
+                    try:
+                        start_process_with_retry(p, module="altcoin")
+                        log_message(
+                            f"Spawned altcoin worker PID {p.pid} for {txt} on GPU {gid if gid is not None else 'CPU'}",
+                            "INFO",
+                        )
+                        processes[gid] = p
+                        queued.add(txt)
+                    except Exception as e:
+                        log_message(
+                            f"❌ Failed to spawn altcoin worker for {txt}: {safe_str(e)}",
+                            "ERROR",
+                            exc_info=True,
+                        )
 
             try:
                 while True:
@@ -1302,12 +1310,20 @@ def start_altcoin_conversion_process(shared_shutdown_event, shared_metrics=None,
     # and therefore cannot be a daemon. Marking it as non-daemonic avoids
     # ``daemonic processes are not allowed to have children`` errors.
     process.daemon = False
-    process.start()
-    log_message(
-        f"🚀 Altcoin derive subprocess PID {process.pid} started with args {proc_args}",
-        "INFO",
-    )
-    return process
+    try:
+        start_process_with_retry(process, module="altcoin")
+        log_message(
+            f"🚀 Altcoin derive subprocess PID {process.pid} started with args {proc_args}",
+            "INFO",
+        )
+        return process
+    except Exception as e:
+        log_message(
+            f"❌ Failed to start altcoin derive subprocess: {safe_str(e)}",
+            "ERROR",
+            exc_info=True,
+        )
+        return None
 
 
 if __name__ == "__main__":

--- a/core/dashboard.py
+++ b/core/dashboard.py
@@ -406,6 +406,8 @@ def _default_metrics():
         "altcoin_gpu_on": False,
         "state": "Initializing",
         "active_processes": [],
+        "popen_failures": {},
+        "last_popen_error": {},
         "csv_check_queue": [],
         "csv_recheck_queue": [],
         "csv_check_progress": {},

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -34,6 +34,7 @@ from core.seed_tracker import (
     record_seed_range,
     get_condensed_ranges,
 )
+from core.utils.process import popen_with_retry
 
 
 # Runtime trackers
@@ -235,11 +236,12 @@ def run_vanitysearch_stream(initial_seed_int, batch_id, index_within_batch, paus
         with open(current_output_path, "w", encoding="utf-8", buffering=1) as outfile:
             logger.info(f"Opened {current_output_path} for writing")
             # Launch VanitySearch as a subprocess and stream output to the file
-            proc = subprocess.Popen(
+            proc = popen_with_retry(
                 cmd,
                 stdout=outfile,
                 stderr=subprocess.STDOUT,
                 env={**os.environ, **gpu_env},
+                module="keygen",
             )
             logger.info(f"Spawned VanitySearch PID {proc.pid} with args {cmd}")
 

--- a/core/utils/process.py
+++ b/core/utils/process.py
@@ -1,0 +1,83 @@
+import subprocess
+import time
+from typing import Sequence
+from multiprocessing import Process
+
+
+def popen_with_retry(
+    cmd: Sequence[str],
+    *,
+    attempts: int = 3,
+    base_delay: float = 1.0,
+    module: str = "general",
+    **kwargs,
+) -> subprocess.Popen:
+    """Launch a subprocess with retry and exponential backoff.
+
+    Parameters
+    ----------
+    cmd: Sequence[str]
+        Command and arguments for ``subprocess.Popen``.
+    attempts: int
+        Number of attempts before giving up. Defaults to 3.
+    base_delay: float
+        Initial delay in seconds for exponential backoff. Defaults to 1.0.
+    module: str
+        Module name for dashboard metrics.
+    **kwargs:
+        Extra keyword arguments forwarded to ``subprocess.Popen``.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return subprocess.Popen(cmd, **kwargs)
+        except Exception as exc:  # pragma: no cover - rare failure
+            last_exc = exc
+            try:
+                from core.dashboard import increment_metric, update_dashboard_stat
+
+                increment_metric(f"popen_failures.{module}")
+                update_dashboard_stat(
+                    f"last_popen_error.{module}", str(exc)
+                )
+            except Exception:
+                pass
+            if attempt == attempts:
+                if last_exc:
+                    raise last_exc
+            time.sleep(base_delay * (2 ** (attempt - 1)))
+    if last_exc:
+        raise last_exc
+
+
+def start_process_with_retry(
+    proc: Process,
+    *,
+    attempts: int = 3,
+    base_delay: float = 1.0,
+    module: str = "general",
+) -> Process:
+    """Start a ``multiprocessing.Process`` with retry/backoff."""
+    last_exc: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            proc.start()
+            return proc
+        except Exception as exc:  # pragma: no cover - rare failure
+            last_exc = exc
+            try:
+                from core.dashboard import increment_metric, update_dashboard_stat
+
+                increment_metric(f"popen_failures.{module}")
+                update_dashboard_stat(
+                    f"last_popen_error.{module}", str(exc)
+                )
+            except Exception:
+                pass
+            if attempt == attempts:
+                if last_exc:
+                    raise last_exc
+            time.sleep(base_delay * (2 ** (attempt - 1)))
+    if last_exc:
+        raise last_exc
+    return proc


### PR DESCRIPTION
## Summary
- add popen_with_retry and start_process_with_retry utilities that report to dashboard
- wrap VanitySearch and altcoin workers in exponential backoff retries
- expose dashboard metrics for popen failures

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68bd78ec59608327aa4be386e9e483c3