### PR TITLE
Refactor alert channel logic into reusable helpers

### DIFF
--- a/core/alerts.py
+++ b/core/alerts.py
@@ -3,8 +3,6 @@ import json
 import csv
 csv.field_size_limit(2**30)  # allow very large CSV fields
 import time
-import smtplib
-import requests
 import threading
 import queue
 import subprocess
@@ -13,8 +11,6 @@ try:
     from twilio.rest import Client
 except Exception:  # handle missing twilio dependency
     Client = None
-from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
 from Crypto.PublicKey import RSA
 from Crypto.Cipher import PKCS1_OAEP
 import base64
@@ -38,6 +34,12 @@ from config.settings import (
 from core.logger import log_message
 from core.dashboard import get_metric
 from core.worker_bootstrap import _safe_set_metric, _safe_inc_metric
+from core.utils.alert_helpers import (
+    send_email_alert,
+    send_telegram_alert,
+    send_discord_alert,
+    send_home_assistant_alert,
+)
 
 # runtime alert flags that can be toggled from the GUI
 ALERT_FLAGS = {
@@ -280,37 +282,24 @@ def alert_match(match_data, test_mode=False):
 
     # 📧 Email Alert
     if ALERT_FLAGS.get("ALERT_EMAIL_ENABLED"):
-        try:
-            msg = MIMEMultipart()
-            msg['From'] = ALERT_EMAIL_FROM
-            msg['To'] = ",".join(ALERT_EMAIL_TO) if isinstance(ALERT_EMAIL_TO, list) else ALERT_EMAIL_TO
-            msg['Subject'] = f"AllInKeys {alert_type}"
-            msg.attach(MIMEText(match_text, 'plain'))
-
-            server = smtplib.SMTP(SMTP_SERVER, SMTP_PORT, timeout=10)
-            server.starttls()
-            server.login(SMTP_USERNAME, SMTP_PASSWORD)
-            server.send_message(msg)
-            server.quit()
-            log_message("[ALERT] ✉️ Email sent", "INFO")
+        if send_email_alert(
+            match_text,
+            ALERT_EMAIL_FROM,
+            ALERT_EMAIL_TO,
+            f"AllInKeys {alert_type}",
+            SMTP_SERVER,
+            SMTP_PORT,
+            SMTP_USERNAME,
+            SMTP_PASSWORD,
+        ):
             _safe_inc_metric("alerts_sent_today.email")
             _safe_inc_metric("alerts_sent_lifetime.email")
-        except Exception as e:
-            log_message(f"❌ Email alert error: {e}", "WARNING")
 
     # 📲 Telegram Alert
     if ALERT_FLAGS.get("ENABLE_TELEGRAM_ALERT"):
-        try:
-            telegram_url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
-            resp = requests.post(telegram_url, json={"chat_id": TELEGRAM_CHAT_ID, "text": match_text}, timeout=10)
-            if resp.ok and resp.json().get("ok"):
-                log_message("[ALERT] 📟 Telegram sent", "INFO")
-                _safe_inc_metric("alerts_sent_today.telegram")
-                _safe_inc_metric("alerts_sent_lifetime.telegram")
-            else:
-                log_message(f"❌ Telegram alert failed: {resp.text}", "ERROR")
-        except Exception as e:
-            log_message(f"❌ Telegram alert error: {e}", "WARNING")
+        if send_telegram_alert(match_text, TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID):
+            _safe_inc_metric("alerts_sent_today.telegram")
+            _safe_inc_metric("alerts_sent_lifetime.telegram")
 
     # 📱 SMS via Twilio
     if ALERT_FLAGS.get("ENABLE_SMS_ALERT") and Client:
@@ -329,35 +318,15 @@ def alert_match(match_data, test_mode=False):
 
     # 💬 Discord Alert
     if ALERT_FLAGS.get("ENABLE_DISCORD_ALERT"):
-        try:
-            data = {"content": match_text}
-            resp = requests.post(DISCORD_WEBHOOK_URL, json=data, timeout=10)
-            if resp.ok:
-                log_message("💬 Discord alert sent.", "INFO")
-                _safe_inc_metric("alerts_sent_today.discord")
-                _safe_inc_metric("alerts_sent_lifetime.discord")
-            else:
-                log_message(f"❌ Discord alert failed: {resp.text}", "ERROR")
-        except Exception as e:
-            log_message(f"❌ Discord alert error: {e}", "ERROR")
+        if send_discord_alert(match_text, DISCORD_WEBHOOK_URL):
+            _safe_inc_metric("alerts_sent_today.discord")
+            _safe_inc_metric("alerts_sent_lifetime.discord")
 
     # 🏠 Home Assistant Alert
     if ALERT_FLAGS.get("ENABLE_HOME_ASSISTANT_ALERT"):
-        try:
-            headers = {
-                "Authorization": f"Bearer {HOME_ASSISTANT_TOKEN}",
-                "Content-Type": "application/json"
-            }
-            payload = {"message": match_text}
-            resp = requests.post(HOME_ASSISTANT_URL, headers=headers, json=payload, timeout=10)
-            if resp.ok:
-                log_message("🏠 Home Assistant alert sent.", "INFO")
-                _safe_inc_metric("alerts_sent_today.home_assistant")
-                _safe_inc_metric("alerts_sent_lifetime.home_assistant")
-            else:
-                log_message(f"❌ Home Assistant alert failed: {resp.text}", "ERROR")
-        except Exception as e:
-            log_message(f"❌ Home Assistant alert error: {e}", "ERROR")
+        if send_home_assistant_alert(match_text, HOME_ASSISTANT_URL, HOME_ASSISTANT_TOKEN):
+            _safe_inc_metric("alerts_sent_today.home_assistant")
+            _safe_inc_metric("alerts_sent_lifetime.home_assistant")
 
     # ☁ PGP + Cloud Upload
     if ALERT_FLAGS.get("ENABLE_CLOUD_UPLOAD"):

--- a/core/utils/alert_helpers.py
+++ b/core/utils/alert_helpers.py
@@ -1,0 +1,78 @@
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from typing import Union
+
+import requests
+
+from core.logger import log_message
+
+
+def send_email_alert(message: str, from_addr: str, to_addrs: Union[str, list], subject: str,
+                     smtp_server: str, smtp_port: int, username: str, password: str,
+                     timeout: int = 10) -> bool:
+    """Send an email alert using SMTP.
+
+    Returns True on success, False otherwise.
+    """
+    try:
+        msg = MIMEMultipart()
+        msg['From'] = from_addr
+        msg['To'] = ",".join(to_addrs) if isinstance(to_addrs, (list, tuple)) else to_addrs
+        msg['Subject'] = subject
+        msg.attach(MIMEText(message, 'plain'))
+
+        server = smtplib.SMTP(smtp_server, smtp_port, timeout=timeout)
+        server.starttls()
+        server.login(username, password)
+        server.send_message(msg)
+        server.quit()
+        log_message("[ALERT] ✉️ Email sent", "INFO")
+        return True
+    except Exception as e:
+        log_message(f"❌ Email alert error: {e}", "WARNING")
+        return False
+
+
+def send_telegram_alert(message: str, bot_token: str, chat_id: str, timeout: int = 10) -> bool:
+    """Send a Telegram message using the bot API."""
+    try:
+        telegram_url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+        resp = requests.post(telegram_url, json={"chat_id": chat_id, "text": message}, timeout=timeout)
+        if resp.ok and resp.json().get("ok"):
+            log_message("[ALERT] 📟 Telegram sent", "INFO")
+            return True
+        log_message(f"❌ Telegram alert failed: {resp.text}", "ERROR")
+    except Exception as e:
+        log_message(f"❌ Telegram alert error: {e}", "WARNING")
+    return False
+
+
+def send_discord_alert(message: str, webhook_url: str, timeout: int = 10) -> bool:
+    """Send an alert to a Discord webhook."""
+    try:
+        resp = requests.post(webhook_url, json={"content": message}, timeout=timeout)
+        if resp.ok:
+            log_message("💬 Discord alert sent.", "INFO")
+            return True
+        log_message(f"❌ Discord alert failed: {resp.text}", "ERROR")
+    except Exception as e:
+        log_message(f"❌ Discord alert error: {e}", "ERROR")
+    return False
+
+
+def send_home_assistant_alert(message: str, url: str, token: str, timeout: int = 10) -> bool:
+    """Send an alert to Home Assistant."""
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    try:
+        resp = requests.post(url, headers=headers, json={"message": message}, timeout=timeout)
+        if resp.ok:
+            log_message("🏠 Home Assistant alert sent.", "INFO")
+            return True
+        log_message(f"❌ Home Assistant alert failed: {resp.text}", "ERROR")
+    except Exception as e:
+        log_message(f"❌ Home Assistant alert error: {e}", "ERROR")
+    return False

--- a/tests/test_alert_helpers.py
+++ b/tests/test_alert_helpers.py
@@ -1,0 +1,96 @@
+import types
+
+import smtplib
+from types import SimpleNamespace
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from core.utils import alert_helpers
+
+
+def disable_logging(monkeypatch):
+    monkeypatch.setattr(alert_helpers, "log_message", lambda *a, **k: None)
+
+
+def test_send_email_alert(monkeypatch):
+    disable_logging(monkeypatch)
+    sent = {}
+
+    class DummySMTP:
+        def __init__(self, server, port, timeout):
+            sent["server"] = server
+            sent["port"] = port
+            sent["timeout"] = timeout
+
+        def starttls(self):
+            sent["starttls"] = True
+
+        def login(self, user, pwd):
+            sent["login"] = (user, pwd)
+
+        def send_message(self, msg):
+            sent["msg"] = msg.get_payload()[0].get_payload()
+
+        def quit(self):
+            sent["quit"] = True
+
+    monkeypatch.setattr(smtplib, "SMTP", DummySMTP)
+
+    result = alert_helpers.send_email_alert(
+        "body", "from@example.com", "to@example.com", "subj",
+        "smtp.example.com", 25, "user", "pw"
+    )
+    assert result is True
+    assert sent["server"] == "smtp.example.com"
+    assert sent["msg"] == "body"
+
+
+def test_send_telegram_alert(monkeypatch):
+    disable_logging(monkeypatch)
+    called = {}
+
+    def fake_post(url, json, timeout):
+        called["url"] = url
+        called["json"] = json
+        return SimpleNamespace(ok=True, json=lambda: {"ok": True})
+
+    monkeypatch.setattr(alert_helpers.requests, "post", fake_post)
+
+    assert alert_helpers.send_telegram_alert("hi", "TOKEN", "CHAT") is True
+    assert "TOKEN" in called["url"]
+    assert called["json"]["chat_id"] == "CHAT"
+
+
+def test_send_discord_alert(monkeypatch):
+    disable_logging(monkeypatch)
+    called = {}
+
+    def fake_post(url, json, timeout):
+        called["url"] = url
+        called["json"] = json
+        return SimpleNamespace(ok=True, text="")
+
+    monkeypatch.setattr(alert_helpers.requests, "post", fake_post)
+
+    assert alert_helpers.send_discord_alert("hello", "http://discord") is True
+    assert called["json"]["content"] == "hello"
+
+
+def test_send_home_assistant_alert(monkeypatch):
+    disable_logging(monkeypatch)
+    called = {}
+
+    def fake_post(url, headers, json, timeout):
+        called["url"] = url
+        called["headers"] = headers
+        called["json"] = json
+        return SimpleNamespace(ok=True, text="")
+
+    monkeypatch.setattr(alert_helpers.requests, "post", fake_post)
+
+    assert alert_helpers.send_home_assistant_alert("msg", "http://ha", "TOKEN") is True
+    assert called["headers"]["Authorization"] == "Bearer TOKEN"
+    assert called["json"]["message"] == "msg"


### PR DESCRIPTION
## Summary
- Extract channel-specific alert senders into `core/utils/alert_helpers.py`
- Use new helpers in `alert_match` to simplify alert dispatch
- Add unit tests covering email, Telegram, Discord, and Home Assistant helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd78faf0c083278d0bbb74487a984a