### PR TITLE
Add targeted tests and coverage reporting

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=config.settings --cov=config.constants --cov=core.seed_tracker --cov=core.puzzle_queue --cov=core.vanity_io --cov=core.logger --cov=core.keygen --cov=core.gpu_scheduler --cov=core.downloader --cov-report=term-missing --cov-fail-under=60

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ eth-account
 python-dotenv
 tzlocal
 # Optional: install pyopencl separately for GPU acceleration
+pytest-cov

--- a/tests/fixtures/btc_addresses_sample.txt
+++ b/tests/fixtures/btc_addresses_sample.txt
@@ -1,0 +1,4 @@
+address,balance
+1ABC,10
+3def,20
+BC1xyz,30

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import importlib
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.modules.pop("core.downloader", None)
+downloader = importlib.import_module("core.downloader")
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_parse_address_lines_skips_header():
+    path = FIXTURES / "btc_addresses_sample.txt"
+    with open(path, "r", encoding="utf-8") as f:
+        addresses = list(downloader.parse_address_lines(f))
+    assert addresses == ["1ABC", "3def", "BC1xyz"]
+
+
+def test_clean_address_file(tmp_path):
+    sample = tmp_path / "sample.txt"
+    sample.write_text((FIXTURES / "btc_addresses_sample.txt").read_text(), encoding="utf-8")
+    downloader.clean_address_file(sample)
+    assert sample.read_text(encoding="utf-8") == "1ABC\n3def\nBC1xyz"
+
+
+def test_load_btc_funded_multi(tmp_path):
+    sample = tmp_path / "btc.txt"
+    sample.write_text("1ABC\n3def\nBC1XYZ\n", encoding="utf-8")
+    result = downloader.load_btc_funded_multi(sample)
+    assert result["p2pkh"] == {"1ABC"}
+    assert result["p2sh"] == {"3def"}
+    assert result["bech32"] == {"bc1xyz"}
+    assert result["all"] == {"1ABC", "3def", "bc1xyz"}

--- a/tests/test_gpu_scheduler.py
+++ b/tests/test_gpu_scheduler.py
@@ -1,0 +1,48 @@
+import multiprocessing
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.modules.pop("core.gpu_scheduler", None)
+gpu_scheduler = importlib.import_module("core.gpu_scheduler")
+
+
+def test_detect_gpu_vendor_respects_setting(monkeypatch):
+    monkeypatch.setattr(gpu_scheduler, "GPU_VENDOR", "nvidia")
+    assert gpu_scheduler._detect_gpu_vendor() == ("nvidia", "nvidia")
+
+
+def run_scheduler_once(backlog, monkeypatch):
+    shared_metrics = {}
+    vanity_flag = multiprocessing.Value("i", 1)
+    altcoin_flag = multiprocessing.Value("i", 0)
+    assignment_flag = multiprocessing.Value("i", 0)
+    shutdown_event = multiprocessing.Event()
+
+    monkeypatch.setattr(gpu_scheduler, "SWING_MODE", True)
+    monkeypatch.setattr(gpu_scheduler, "_detect_gpu_vendor", lambda: (None, None))
+    monkeypatch.setattr("core.worker_bootstrap.ensure_metrics_ready", lambda m: None)
+
+    metrics = {}
+    monkeypatch.setattr("core.worker_bootstrap._safe_set_metric", lambda k, v: metrics.update({k: v}))
+    monkeypatch.setattr(gpu_scheduler.os, "listdir", lambda p: [f"f{i}.txt" for i in range(backlog)])
+    monkeypatch.setattr(gpu_scheduler.time, "sleep", lambda s: shutdown_event.set())
+
+    gpu_scheduler.monitor_backlog_and_reassign(
+        shared_metrics, vanity_flag, altcoin_flag, assignment_flag, shutdown_event
+    )
+    return vanity_flag.value, altcoin_flag.value, assignment_flag.value, metrics.get("gpu_assignment")
+
+
+def test_monitor_backlog_high(monkeypatch):
+    v, a, assign, assignment = run_scheduler_once(120, monkeypatch)
+    assert (v, a, assign) == (0, 1, 1)
+    assert assignment == "altcoin"
+
+
+def test_monitor_backlog_low(monkeypatch):
+    v, a, assign, assignment = run_scheduler_once(10, monkeypatch)
+    assert (v, a, assign) == (1, 0, 0)
+    assert assignment == "vanity"

--- a/tests/test_keygen_seed.py
+++ b/tests/test_keygen_seed.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from config.constants import SECP256K1_ORDER
+
+for mod in ["core.keygen", "core.dashboard"]:
+    sys.modules.pop(mod, None)
+keygen = importlib.import_module("core.keygen")
+
+
+def test_generate_seed_from_batch_basic():
+    seed = keygen.generate_seed_from_batch(0, 0)
+    assert seed == 1 << 128
+    seed2 = keygen.generate_seed_from_batch(1, 5, batch_size=10)
+    assert seed2 == (1 * 10 + 5) + (1 << 128)
+
+
+def test_generate_seed_from_batch_overflow():
+    batch_size = 10
+    batch_id = SECP256K1_ORDER // batch_size
+    index = SECP256K1_ORDER % batch_size + 1
+    assert keygen.generate_seed_from_batch(batch_id, index, batch_size) is None
+
+
+def test_generate_random_seed_queue(monkeypatch):
+    keygen._SEED_QUEUE = [42]
+    seed = keygen.generate_random_seed()
+    assert seed == 42
+    assert keygen._SEED_QUEUE == []
+
+
+def test_generate_random_seed_fills_queue(monkeypatch):
+    keygen._SEED_QUEUE = []
+    monkeypatch.setattr(keygen, "seed_in_used_range", lambda c, ranges=None: False)
+    monkeypatch.setattr(keygen, "get_condensed_ranges", lambda: [])
+    monkeypatch.setattr(keygen.secrets, "randbelow", lambda span: 1)
+    seed = keygen.generate_random_seed(min_bits=128)
+    assert seed == (1 << 128) + 1
+    assert len(keygen._SEED_QUEUE) == keygen.SEED_QUEUE_SIZE - 1


### PR DESCRIPTION
## Summary
- add deterministic key generation tests for seed queue and batch math
- test GPU scheduler backlog switching logic
- verify downloader address parsing and classification
- integrate pytest-cov with coverage threshold
- provide sample BTC address fixture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd78fdf4188327ac5dfaa53898cbe8