### PR TITLE
Add plugin entry point system and templates

### DIFF
--- a/core/worker_bootstrap.py
+++ b/core/worker_bootstrap.py
@@ -3,6 +3,12 @@ import time
 from core.logger import log_message
 
 try:
+    # ``importlib.metadata`` is stdlib in 3.8+, but fall back if needed
+    from importlib.metadata import entry_points
+except Exception:  # pragma: no cover - very old Python
+    from importlib_metadata import entry_points  # type: ignore
+
+try:
     from core.dashboard import init_shared_metrics, set_metric, increment_metric
 except Exception:
     # Fallback shims if dashboard import fails very early
@@ -11,6 +17,7 @@ except Exception:
     def increment_metric(*_a, **_k): return None
 
 _metrics_ready = {"ok": False}
+_plugins_loaded = False
 
 
 def ensure_metrics_ready(shared_dict=None):
@@ -43,3 +50,46 @@ def _safe_inc_metric(name, amount=1):
         increment_metric(name, amount)
     except Exception:
         pass
+
+
+def load_plugins():
+    """Dynamically load derivation and alert plugins via entry points.
+
+    This uses the ``allinkeys.plugins.derivation`` and
+    ``allinkeys.plugins.alert`` entry point groups. Plugins are expected to
+    register themselves with the framework when imported.
+    """
+
+    global _plugins_loaded
+    if _plugins_loaded:
+        return
+
+    def _load_group(group: str):
+        try:
+            eps = entry_points()  # type: ignore[arg-type]
+            # ``select`` is available on Python 3.10+; fall back otherwise
+            try:
+                selected = eps.select(group=group)
+            except Exception:  # pragma: no cover - py3.8/3.9
+                selected = [ep for ep in eps.get(group, [])]
+            for ep in selected:
+                try:
+                    loaded = ep.load()
+                    if callable(loaded):
+                        loaded()
+                    log_message(
+                        f"[worker_bootstrap] Loaded plugin {ep.name} from {group}",
+                        "DEBUG",
+                    )
+                except Exception as exc:  # pragma: no cover - plugin failure
+                    log_message(f"[worker_bootstrap] Failed loading {ep.name}: {exc}", "ERROR")
+        except Exception as exc:  # pragma: no cover - entry point failure
+            log_message(f"[worker_bootstrap] Plugin discovery failed for {group}: {exc}", "ERROR")
+
+    _load_group("allinkeys.plugins.derivation")
+    _load_group("allinkeys.plugins.alert")
+    _plugins_loaded = True
+
+
+# Load plugins on import so they are available in all workers
+load_plugins()

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,19 @@
+"""Plugin registry for All In Keys.
+
+Plugins can register derivation or alert handlers by calling the helper
+functions defined here. Loaded plugins are stored in ``derivation_plugins`` and
+``alert_plugins`` dictionaries mapping a plugin name to a callable.
+"""
+
+derivation_plugins = {}
+alert_plugins = {}
+
+
+def register_derivation(name, func):
+    """Register a derivation plugin."""
+    derivation_plugins[name] = func
+
+
+def register_alert(name, func):
+    """Register an alert plugin."""
+    alert_plugins[name] = func

--- a/plugins/example/__init__.py
+++ b/plugins/example/__init__.py
@@ -1,0 +1,5 @@
+"""Example plugin implementations for All In Keys."""
+
+# This package contains two basic templates demonstrating how to create
+# derivation and alert plugins. They are not used by default but serve as
+# starting points for external packages.

--- a/plugins/example/alert_plugin.py
+++ b/plugins/example/alert_plugin.py
@@ -1,0 +1,19 @@
+"""Sample alert plugin.
+
+Expose via entry point::
+
+    [options.entry_points]
+    allinkeys.plugins.alert =
+        example = your_pkg.alert:register
+"""
+
+from allinkeys.plugins import register_alert
+
+
+def alert(message: str):
+    """Dummy alert that prints a message."""
+    print(f"example alert: {message}")
+
+
+def register():
+    register_alert("example", alert)

--- a/plugins/example/derivation_plugin.py
+++ b/plugins/example/derivation_plugin.py
@@ -1,0 +1,22 @@
+"""Sample derivation plugin.
+
+To use this plugin in your own package, expose it via an entry point in your
+``setup.cfg`` or ``pyproject.toml`` like so::
+
+    [options.entry_points]
+    allinkeys.plugins.derivation =
+        example = your_pkg.example:register
+
+The function registered here simply echoes the provided seed.
+"""
+
+from allinkeys.plugins import register_derivation
+
+
+def derive(seed: str):
+    """Dummy derivation that returns the seed unchanged."""
+    return {"echo": seed}
+
+
+def register():
+    register_derivation("example", derive)


### PR DESCRIPTION
## Summary
- add plugin registry and example derivation/alert plugins
- load plugin entry points in worker_bootstrap
- provide templates for plugin developers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd79046d2083279ee29835d63a4328