### PR TITLE
Add premium licensing module and service

### DIFF
--- a/docs/premium.md
+++ b/docs/premium.md
@@ -1,0 +1,20 @@
+# Premium Monetization Strategy
+
+AllInKeys offers optional premium features that accelerate key search and provide enterprise-level support.
+
+## Subscription Tiers
+- **Basic** – Free tier with community support and standard features.
+- **Pro** – Includes access to the faster address database for improved lookup performance.
+- **Enterprise** – Unlocks distributed GPU cluster capabilities, access to precomputed ranges service, and priority support.
+
+## Integration Steps
+1. Purchase a subscription and receive a license token.
+2. Set the token as an environment variable:
+   ```bash
+   export ALLINKEYS_LICENSE="YOUR-TOKEN-HERE"
+   ```
+3. Use `PremiumManager` to verify the token and enable premium functionality.
+4. (Optional) Run the FastAPI service to distribute precomputed ranges and submit telemetry:
+   ```bash
+   python -m premium.service
+   ```

--- a/premium/__init__.py
+++ b/premium/__init__.py
@@ -1,0 +1,5 @@
+"""Premium module for license validation and feature gating."""
+
+from .license import PremiumManager
+
+__all__ = ["PremiumManager"]

--- a/premium/license.py
+++ b/premium/license.py
@@ -1,0 +1,42 @@
+"""License token handling and feature checks for premium functionality."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from typing import Dict, Set
+
+# Mapping of license tokens to the set of enabled features.
+LICENSE_FEATURES: Dict[str, Set[str]] = {
+    # Example tokens for illustration. Real tokens should be generated securely.
+    "PREMIUM-CLUSTER": {"distributed_gpu", "fast_address_db"},
+    "PREMIUM-DB": {"fast_address_db"},
+}
+
+
+@dataclass
+class PremiumManager:
+    """Helper class for validating license tokens and querying features."""
+
+    token: str | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        if self.token is None:
+            self.token = os.getenv("ALLINKEYS_LICENSE")
+
+    def has_valid_license(self) -> bool:
+        """Return True if the current token is recognized."""
+        return bool(self.token) and self.token in LICENSE_FEATURES
+
+    def enabled_features(self) -> Set[str]:
+        """Return the set of features available for the token."""
+        if not self.has_valid_license():
+            return set()
+        return LICENSE_FEATURES[self.token]
+
+    def distributed_gpu_enabled(self) -> bool:
+        """Check if the distributed GPU cluster feature is unlocked."""
+        return "distributed_gpu" in self.enabled_features()
+
+    def fast_address_db_enabled(self) -> bool:
+        """Check if the faster address database feature is unlocked."""
+        return "fast_address_db" in self.enabled_features()

--- a/premium/service.py
+++ b/premium/service.py
@@ -1,0 +1,44 @@
+"""Simple REST service for distributing precomputed ranges and receiving telemetry."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+try:  # FastAPI is optional at runtime unless the service is started.
+    from fastapi import FastAPI, HTTPException
+except ModuleNotFoundError:  # pragma: no cover - handled if FastAPI not installed
+    FastAPI = None  # type: ignore
+    HTTPException = Exception  # type: ignore
+
+from .license import PremiumManager
+
+app = FastAPI(title="AllInKeys Premium Service") if FastAPI else None
+
+
+if app:
+    @app.get("/ranges")
+    def get_ranges(token: str) -> Dict[str, List[List[int]]]:
+        pm = PremiumManager(token)
+        if not pm.distributed_gpu_enabled():
+            raise HTTPException(status_code=403, detail="Premium license required")
+        # Placeholder ranges; real implementation would fetch from database.
+        ranges = [[0, 1000], [1000, 2000]]
+        return {"ranges": ranges}
+
+    @app.post("/telemetry")
+    def telemetry(data: Dict[str, Any]) -> Dict[str, str]:
+        # In reality, this would persist telemetry for analytics.
+        print("Telemetry received", data)  # noqa: T201 - diagnostic output
+        return {"status": "ok"}
+
+
+def run(host: str = "0.0.0.0", port: int = 8000) -> None:
+    """Run the premium FastAPI service."""
+    if not app:
+        raise RuntimeError("FastAPI is required to run the premium service")
+    import uvicorn
+
+    uvicorn.run(app, host=host, port=port)
+
+if __name__ == "__main__":
+    run()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,6 @@ GPUtil
 eth-account
 python-dotenv
 tzlocal
+fastapi
+uvicorn
 # Optional: install pyopencl separately for GPU acceleration


### PR DESCRIPTION
## Summary
- add `PremiumManager` for license token validation and feature gating
- expose FastAPI service for distributing ranges and accepting telemetry
- document subscription tiers and integration steps in premium docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd790f4b508327a6f13e9876b20f78