### PR TITLE
Fix scheduler/keygen compile errors and document usage

### DIFF
--- a/core/gpu_scheduler.py
+++ b/core/gpu_scheduler.py
@@ -3,6 +3,7 @@
 import os
 import multiprocessing
 import threading
+import time
 
 try:
     import pyopencl as cl

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -307,12 +307,12 @@ def run_vanitysearch_stream(initial_seed_int, batch_id, index_within_batch, paus
                         first_seed = seed_int
                     last_seed_local = seed_int
                     lines += 1
-            if lines >= MAX_OUTPUT_LINES:
-                logger.info(
-                    f"📏 Max line count reached ({MAX_OUTPUT_LINES} lines). Rotating file {Path(current_output_path).name}"
-                )
-                proc.terminate()
-                break
+                if lines >= MAX_OUTPUT_LINES:
+                    logger.info(
+                        f"📏 Max line count reached ({MAX_OUTPUT_LINES} lines). Rotating file {Path(current_output_path).name}"
+                    )
+                    proc.terminate()
+                    break
 
             proc.stdout.close()
             proc.wait()

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,41 @@ pip install -r requirements.txt
 
 Copy `.env.example` to `.env` and fill in any credentials needed for alert channels (email, Telegram, Twilio, etc.).
 
+## 🚀 Quick Start
+
+1. **Start the full pipeline**
+
+   ```bash
+   python main.py
+   ```
+
+   The orchestration script launches key generation, backlog conversion, and any enabled alert or dashboard modules according to `config/settings.py`.
+
+2. **Run individual modules**
+
+   Each component can be invoked directly for isolated testing or debugging:
+
+   ```bash
+   python -m core.keygen           # GPU/CPU vanity key generation
+   python -m core.altcoin_derive   # Derive altcoin addresses from seeds
+   python -m core.csv_checker      # Compare generated addresses to funded lists
+   python -m ui.dashboard_gui      # Launch Tkinter dashboard only
+   ```
+
+3. **Run in Docker**
+
+   ```bash
+   docker compose up --build
+   ```
+
+   Use the Compose file to scale across multiple GPUs or hosts.
+
+4. **Run tests**
+
+   ```bash
+   pytest
+   ```
+
 ### 📁 Directory Overview
 
 ```
@@ -340,6 +375,24 @@ Produces `dist/main.exe` — a standalone binary.
 | BTC  | `18RWVyEciKq8NLz5Q1uEzNGXzTs5ivo37y` |
 | DOGE | `DPoHJNbYHEuvNHyCFcUnvtTVmRDMNgnAs5` |
 | ETH  | `0xCb8B2937D60c47438562A2E53d08B85865B57741` |
+
+---
+
+## 📝 Changelog
+
+### [Unreleased]
+
+- Added `env_path` helper and migrated many modules to `pathlib`-based paths
+- Introduced `--purge` command with dry-run for cleaning old downloads
+- Added opt-in telemetry module and consent logging with alert redaction
+- Added Docker support and compose configuration
+- Implemented dashboard authentication and premium licensing module
+- Added plugin entry point system and templates
+- Improved GPU detection, selection, and scheduler tests
+- Enforced HTTPS downloads with checksum verification
+- Added processing throughput metrics and SQLite fallback for funded address lookup
+- Stream VanitySearch output to track seeds and expanded binary detection
+- Enhanced mnemonic mode with full BIP-39 language support and multilingual output
 
 ---
 

--- a/tests/test_gpu_scheduler.py
+++ b/tests/test_gpu_scheduler.py
@@ -28,7 +28,14 @@ def run_scheduler_once(backlog, monkeypatch):
     metrics = {}
     monkeypatch.setattr("core.worker_bootstrap._safe_set_metric", lambda k, v: metrics.update({k: v}))
     monkeypatch.setattr(gpu_scheduler.os, "listdir", lambda p: [f"f{i}.txt" for i in range(backlog)])
-    monkeypatch.setattr(gpu_scheduler.time, "sleep", lambda s: shutdown_event.set())
+    class ImmediateTimer:
+        def __init__(self, interval, func):
+            self.func = func
+
+        def start(self):
+            shutdown_event.set()
+
+    monkeypatch.setattr(gpu_scheduler.threading, "Timer", lambda i, f: ImmediateTimer(i, f))
 
     gpu_scheduler.monitor_backlog_and_reassign(
         shared_metrics, vanity_flag, altcoin_flag, assignment_flag, shutdown_event

--- a/tests/test_puzzle_queue.py
+++ b/tests/test_puzzle_queue.py
@@ -32,10 +32,12 @@ except Exception:  # pragma: no cover
     sys.modules["base58"] = types.SimpleNamespace(b58encode=lambda b: b"1addr")
 
 import config.settings as settings
+import core.paths as paths
 
 
 def test_puzzle_queue_sequential(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(paths, "LOG_DIR", tmp_path)
     pq = importlib.reload(importlib.import_module("core.puzzle_queue"))
     pq.init_work_queue()
     start = 1 << (76 - 1)
@@ -47,6 +49,7 @@ def test_puzzle_queue_sequential(tmp_path, monkeypatch):
 
 def test_puzzle_queue_specific_chunk(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(paths, "LOG_DIR", tmp_path)
     pq = importlib.reload(importlib.import_module("core.puzzle_queue"))
     pq.init_work_queue()
     start_bound, _ = pq._get_bounds(76)


### PR DESCRIPTION
## Summary
- fix break indent in keygen to avoid SyntaxError
- add missing `time` import to GPU scheduler and adjust tests
- patch puzzle queue tests, add Quick Start guide and changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `mypy .` *(fails: missing requests stubs, settings module mapping)*

------
https://chatgpt.com/codex/tasks/task_e_68c090f32bc48327ab32aed1b5dddb81