### PR TITLE
fix: import missing logger in network utils

### DIFF
--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import importlib
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.modules.pop("utils.network_utils", None)
+network_utils = importlib.import_module("utils.network_utils")
+
+
+def test_download_file_requires_https(tmp_path):
+    dest = tmp_path / "out.txt"
+    with pytest.raises(ValueError, match="HTTPS is required"):
+        network_utils.download_file("http://example.com/data.txt", str(dest))

--- a/utils/network_utils.py
+++ b/utils/network_utils.py
@@ -3,7 +3,7 @@ import hashlib
 import requests
 from urllib.parse import urlparse
 
-from core.logger import get_logger
+from core.logger import get_logger, log_message
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- import `log_message` in network_utils to avoid NameError
- add unit test validating HTTPS requirement in network_utils

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c094f106dc8327b2fea46d2b8ec18a