### PR TITLE
Skip validation for placeholder download hashes

### DIFF
--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -14,3 +14,28 @@ def test_download_file_requires_https(tmp_path):
     dest = tmp_path / "out.txt"
     with pytest.raises(ValueError, match="HTTPS is required"):
         network_utils.download_file("http://example.com/data.txt", str(dest))
+
+
+def test_download_file_skips_placeholder_sha256(tmp_path, monkeypatch):
+    dest = tmp_path / "out.txt"
+    content = b"hello world"
+
+    class DummyResponse:
+        def __init__(self):
+            self.headers = {"Content-Length": str(len(content))}
+
+        def iter_content(self, chunk_size=8192):
+            yield content
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, stream=True, **kwargs):
+        return DummyResponse()
+
+    monkeypatch.setattr(network_utils.requests, "get", fake_get)
+    network_utils.download_file(
+        "https://example.com/data.txt", str(dest), expected_sha256="0" * 64
+    )
+
+    assert dest.read_bytes() == content

--- a/utils/network_utils.py
+++ b/utils/network_utils.py
@@ -21,8 +21,10 @@ def download_file(
 
     If ``expected_sha256`` is provided and does not match the computed digest the
     file is deleted and a security alert is logged before raising ``ValueError``.
-    ``progress_cb`` is called with ``(downloaded_bytes, total_bytes)`` after each
-    chunk allowing callers to track progress.
+    An ``expected_sha256`` of 64 zeroes is treated as a placeholder and
+    disables verification. ``progress_cb`` is called with
+    ``(downloaded_bytes, total_bytes)`` after each chunk allowing callers to
+    track progress.
     """
 
     parsed = urlparse(url)
@@ -49,13 +51,15 @@ def download_file(
                 progress_cb(downloaded, total)
 
     digest = hasher.hexdigest()
-    if expected_sha256 and digest.lower() != expected_sha256.lower():
-        log_message(
-            f"SHA256 mismatch for {url}: expected {expected_sha256} got {digest}",
-            "ALERT",
-        )
-        try:
-            os.remove(dest_path)
-        finally:
-            pass
-        raise ValueError("SHA256 mismatch")
+    if expected_sha256:
+        expected = expected_sha256.lower()
+        if expected != "0" * 64 and digest.lower() != expected:
+            log_message(
+                f"SHA256 mismatch for {url}: expected {expected_sha256} got {digest}",
+                "ALERT",
+            )
+            try:
+                os.remove(dest_path)
+            finally:
+                pass
+            raise ValueError("SHA256 mismatch")


### PR DESCRIPTION
## Summary
- allow downloads to skip SHA256 verification when expected hash is 64 zeroes
- add regression test for placeholder hash handling in download helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c097dc333c83278845fb28deb9215c