### PR TITLE
fix: unify vanity output env aliases

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -84,7 +84,14 @@ UNIQUE_DIR = env_path("ALLINKEYS_UNIQUE_DIR", DOWNLOADS_DIR / "unique")
 # Where matches and encrypted alerts are archived
 MATCHES_DIR = env_path("ALLINKEYS_MATCHES_DIR", BASE_DIR / "matches")
 # VanitySearch text outputs
-VANITY_TXT_DIR = env_path("ALLINKEYS_VANITY_TXT_DIR", BASE_DIR / "vanity_output")
+# ``ALLINKEYS_VANITY_OUTPUT_DIR`` is the newer variable while
+# ``ALLINKEYS_VANITY_TXT_DIR`` is kept for backward compatibility. Prefer the
+# TXT variant when both are set to match historical behaviour.
+_VANITY_DIR_DEFAULT = BASE_DIR / "vanity_output"
+VANITY_TXT_DIR = env_path(
+    "ALLINKEYS_VANITY_TXT_DIR",
+    env_path("ALLINKEYS_VANITY_OUTPUT_DIR", _VANITY_DIR_DEFAULT),
+)
 VANITY_OUTPUT_DIR = VANITY_TXT_DIR  # legacy alias
 # Mnemonic mode text outputs
 MNEMONIC_TXT_DIR = env_path("ALLINKEYS_MNEMONIC_TXT_DIR", BASE_DIR / "mnemonic_output")

--- a/core/paths.py
+++ b/core/paths.py
@@ -26,7 +26,12 @@ DOWNLOADS_DIR: Path = _env_path(
 )
 OUTPUT_DIR: Path = _env_path("ALLINKEYS_OUTPUT_DIR", Path(getattr(settings, "OUTPUT_DIR", BASE_DIR / "output")))
 CSV_DIR: Path = _env_path("ALLINKEYS_CSV_DIR", OUTPUT_DIR / "csv")
-VANITY_OUTPUT_DIR: Path = _env_path("ALLINKEYS_VANITY_OUTPUT_DIR", BASE_DIR / "vanity_output")
+# Support both ``ALLINKEYS_VANITY_OUTPUT_DIR`` and the legacy
+# ``ALLINKEYS_VANITY_TXT_DIR`` for vanity search outputs.
+VANITY_OUTPUT_DIR: Path = _env_path(
+    "ALLINKEYS_VANITY_OUTPUT_DIR",
+    _env_path("ALLINKEYS_VANITY_TXT_DIR", BASE_DIR / "vanity_output"),
+)
 MATCH_LOG_DIR: Path = _env_path("ALLINKEYS_MATCH_LOG_DIR", Path(getattr(settings, "MATCH_LOG_DIR", LOG_DIR)))
 
 


### PR DESCRIPTION
## Summary
- allow BOTH ALLINKEYS_VANITY_OUTPUT_DIR and ALLINKEYS_VANITY_TXT_DIR environment variables
- ensure common path helper supports legacy vanity txt dir alias

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c098e31dec8327aa7ef60d870682c6