### PR TITLE
Nest vanity and mnemonic outputs within main output folder

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -86,15 +86,18 @@ MATCHES_DIR = env_path("ALLINKEYS_MATCHES_DIR", BASE_DIR / "matches")
 # VanitySearch text outputs
 # ``ALLINKEYS_VANITY_OUTPUT_DIR`` is the newer variable while
 # ``ALLINKEYS_VANITY_TXT_DIR`` is kept for backward compatibility. Prefer the
-# TXT variant when both are set to match historical behaviour.
-_VANITY_DIR_DEFAULT = BASE_DIR / "vanity_output"
+# TXT variant when both are set to match historical behaviour. Defaults are now
+# nested under ``output/`` to mirror the CSV structure.
+_VANITY_DIR_DEFAULT = BASE_DIR / "output" / "vanity_output"
 VANITY_TXT_DIR = env_path(
     "ALLINKEYS_VANITY_TXT_DIR",
     env_path("ALLINKEYS_VANITY_OUTPUT_DIR", _VANITY_DIR_DEFAULT),
 )
 VANITY_OUTPUT_DIR = VANITY_TXT_DIR  # legacy alias
 # Mnemonic mode text outputs
-MNEMONIC_TXT_DIR = env_path("ALLINKEYS_MNEMONIC_TXT_DIR", BASE_DIR / "mnemonic_output")
+MNEMONIC_TXT_DIR = env_path(
+    "ALLINKEYS_MNEMONIC_TXT_DIR", BASE_DIR / "output" / "mnemonic_output"
+)
 # Local audio clips for alerts
 SOUND_CLIPS_DIR = env_path("ALLINKEYS_SOUND_CLIPS_DIR", BASE_DIR / "alerts" / "sounds")
 CHECKPOINT_PATH = env_path("ALLINKEYS_CHECKPOINT_PATH", LOG_DIR / "restore_checkpoint.json")

--- a/core/paths.py
+++ b/core/paths.py
@@ -27,10 +27,14 @@ DOWNLOADS_DIR: Path = _env_path(
 OUTPUT_DIR: Path = _env_path("ALLINKEYS_OUTPUT_DIR", Path(getattr(settings, "OUTPUT_DIR", BASE_DIR / "output")))
 CSV_DIR: Path = _env_path("ALLINKEYS_CSV_DIR", OUTPUT_DIR / "csv")
 # Support both ``ALLINKEYS_VANITY_OUTPUT_DIR`` and the legacy
-# ``ALLINKEYS_VANITY_TXT_DIR`` for vanity search outputs.
+# ``ALLINKEYS_VANITY_TXT_DIR`` for vanity search outputs. Defaults now live
+# under ``output/`` alongside CSVs.
 VANITY_OUTPUT_DIR: Path = _env_path(
     "ALLINKEYS_VANITY_OUTPUT_DIR",
-    _env_path("ALLINKEYS_VANITY_TXT_DIR", BASE_DIR / "vanity_output"),
+    _env_path("ALLINKEYS_VANITY_TXT_DIR", OUTPUT_DIR / "vanity_output"),
+)
+MNEMONIC_OUTPUT_DIR: Path = _env_path(
+    "ALLINKEYS_MNEMONIC_TXT_DIR", OUTPUT_DIR / "mnemonic_output"
 )
 MATCH_LOG_DIR: Path = _env_path("ALLINKEYS_MATCH_LOG_DIR", Path(getattr(settings, "MATCH_LOG_DIR", LOG_DIR)))
 
@@ -41,6 +45,6 @@ def ensure_dirs() -> None:
     This preserves the directory structure required by the application and CI
     while avoiding exceptions on re-creation.
     """
-    for d in (LOG_DIR, DOWNLOADS_DIR, OUTPUT_DIR, CSV_DIR, VANITY_OUTPUT_DIR, MATCH_LOG_DIR):
+    for d in (LOG_DIR, DOWNLOADS_DIR, OUTPUT_DIR, CSV_DIR, VANITY_OUTPUT_DIR, MNEMONIC_OUTPUT_DIR, MATCH_LOG_DIR):
         Path(d).mkdir(parents=True, exist_ok=True)
 

--- a/core/utils/retention.py
+++ b/core/utils/retention.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Iterable, Tuple, List
 
 from core.logger import log_message
-from core.paths import CSV_DIR, VANITY_OUTPUT_DIR
+from core.paths import CSV_DIR, VANITY_OUTPUT_DIR, MNEMONIC_OUTPUT_DIR
 
 
 EXCLUDE_EXTENSIONS = {".log"}
@@ -29,7 +29,7 @@ def _should_skip(path: Path) -> bool:
 
 
 def _iter_targets() -> Iterable[Path]:
-    for root in (VANITY_OUTPUT_DIR, CSV_DIR):
+    for root in (VANITY_OUTPUT_DIR, CSV_DIR, MNEMONIC_OUTPUT_DIR):
         if not Path(root).exists():
             continue
         for p in Path(root).rglob("*"):
@@ -38,7 +38,7 @@ def _iter_targets() -> Iterable[Path]:
 
 
 def purge_older_than(days: int, *, dry_run: bool = False) -> Tuple[int, List[str]]:
-    """Delete files older than N days in vanity_output/ and output/csv/.
+    """Delete files older than N days in vanity_output/, mnemonic_output/, and output/csv/.
 
     Returns a tuple (count, messages) describing actions performed or planned.
     """

--- a/readme.md
+++ b/readme.md
@@ -99,8 +99,9 @@ allinkeys/
 ├── Downloads/               # Downloaded funded address lists
 ├── logs/                    # Runtime logs and checkpoints
 ├── output/
-│   └── csv/                 # Converted address batches
-├── vanity_output/           # Raw VanitySearch batches (.txt)
+│   ├── csv/                 # Converted address batches
+│   ├── vanity_output/       # Raw VanitySearch batches (.txt)
+│   └── mnemonic_output/     # Mnemonic mode output
 ├── .env.example
 ├── main.py                  # Orchestrates modules
 └── requirements.txt
@@ -162,8 +163,8 @@ AllInKeys stores logs, downloads and output under the repository root by default
 | `ALLINKEYS_CSV_DIR` | `BASE_DIR/output/csv` | Converted CSV output |
 | `ALLINKEYS_DOWNLOADS_DIR` | `BASE_DIR/Downloads` | Downloaded address lists |
 | `ALLINKEYS_MATCHES_DIR` | `BASE_DIR/matches` | Archive of matches and alerts |
-| `ALLINKEYS_VANITY_TXT_DIR` | `BASE_DIR/vanity_output` | VanitySearch text batches |
-| `ALLINKEYS_MNEMONIC_TXT_DIR` | `BASE_DIR/mnemonic_output` | Mnemonic mode output |
+| `ALLINKEYS_VANITY_TXT_DIR` | `BASE_DIR/output/vanity_output` | VanitySearch text batches |
+| `ALLINKEYS_MNEMONIC_TXT_DIR` | `BASE_DIR/output/mnemonic_output` | Mnemonic mode output |
 
 Example:
 
@@ -240,7 +241,7 @@ python main.py --only btc --puzzle 71 --chunk 5  # resume at chunk 5
 AllInKeys can also generate BIP‑39 mnemonics and derive keys directly
 without running VanitySearch.  Enable it with `--mnemonic` and select the
 mnemonic length via flags like `--12words` or `--24words`.  Output files
-are written to `mnemonic_output/`.  All related options are grouped under
+are written to `output/mnemonic_output/`.  All related options are grouped under
 **Mnemonic Mode** in `python main.py --help`.
 
 Example invocations:


### PR DESCRIPTION
## Summary
- Default vanity search and mnemonic output paths now reside under `output/`
- Added `MNEMONIC_OUTPUT_DIR` path helper and updated retention utilities
- Documented new locations and environment variable defaults

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0a94dcec48327b13d2e339d1922e9