### PR TITLE
Normalize ensure_dir return type

### DIFF
--- a/core/vanity_io.py
+++ b/core/vanity_io.py
@@ -1,13 +1,23 @@
 import os
 import time
-from typing import Optional, BinaryIO
+from typing import Optional, BinaryIO, Union
 from pathlib import Path
 
 
-def ensure_dir(path: str) -> str:
-    """Create ``path`` if missing and return it."""
-    Path(path).mkdir(parents=True, exist_ok=True)
-    return path
+def ensure_dir(path: Union[str, Path]) -> str:
+    """Create ``path`` if missing and return it as a string.
+
+    Historically ``ensure_dir`` returned the same object that was passed in,
+    which could be a :class:`Path`.  Callers such as :class:`RollingAtomicWriter`
+    and ``tempfile`` always expect a string representation, so returning the
+    original ``Path`` could lead to subtle inconsistencies on older Python
+    versions or when concatenating paths.  Normalising to ``str`` keeps the
+    return type predictable while still accepting ``Path`` instances.
+    """
+
+    p = Path(path)
+    p.mkdir(parents=True, exist_ok=True)
+    return str(p)
 
 
 class RollingAtomicWriter:

--- a/tests/test_vanity_io.py
+++ b/tests/test_vanity_io.py
@@ -1,6 +1,6 @@
 import time
 from pathlib import Path
-from core.vanity_io import RollingAtomicWriter
+from core.vanity_io import RollingAtomicWriter, ensure_dir
 
 
 def test_time_based_rotation(tmp_path):
@@ -20,3 +20,10 @@ def test_time_based_rotation(tmp_path):
     assert first_path != second_path
     assert first_path.exists()
     assert second_path.exists()
+
+
+def test_ensure_dir_returns_string(tmp_path):
+    subdir = tmp_path / "nested"
+    result = ensure_dir(subdir)
+    assert isinstance(result, str)
+    assert Path(result).exists()


### PR DESCRIPTION
## Summary
- ensure ensure_dir always returns a string path and document rationale
- add regression test verifying ensure_dir's return type

## Testing
- `PYTHONPATH=. PYTEST_ADDOPTS=--no-cov pytest tests/test_vanity_io.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0c0b9ff388327a0b15976ac356011