### PR TITLE
Fix vanity output directory logging and add regression test

### DIFF
--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -372,7 +372,12 @@ def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) 
     Streams stdout into RollingAtomicWriter with atomic rotation.
     """
     out_dir = ensure_dir(VANITY_TXT_DIR)
-    logger.info(f"Vanity output directory: {out_dir.resolve()}")
+    # ``ensure_dir`` now returns a string path. Wrap with ``Path`` so ``resolve``
+    # is always available while still providing the string to callers that expect
+    # one. The previous direct ``out_dir.resolve()`` call triggered an
+    # ``AttributeError`` once ``ensure_dir`` began normalising to ``str``,
+    # preventing VanitySearch from writing any output files.
+    logger.info(f"Vanity output directory: {Path(out_dir).resolve()}")
     exe = _resolve_exe()
     if not exe:
         logger.error("❌ VanitySearch binary not found.")

--- a/tests/test_vanity_runner.py
+++ b/tests/test_vanity_runner.py
@@ -1,0 +1,36 @@
+import io
+from pathlib import Path
+
+from core import vanity_runner
+
+
+class DummyProc:
+    def __init__(self, lines):
+        self.stdout = io.StringIO("\n".join(lines))
+
+    def poll(self):
+        # Return 0 when all lines have been read
+        return 0 if self.stdout.tell() >= len(self.stdout.getvalue()) else None
+
+    def wait(self, timeout=None):
+        return 0
+
+    def terminate(self):
+        pass
+
+
+def test_run_vanity_generator_creates_output(tmp_path, monkeypatch):
+    """Ensure vanity generator writes output files even when ensure_dir returns str."""
+    # Patch dependencies so we don't call the real binary
+    monkeypatch.setattr(vanity_runner, "_resolve_exe", lambda: "vanity_mock")
+    monkeypatch.setattr(vanity_runner, "_popen_stream", lambda args: DummyProc([
+        "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+    ]))
+    monkeypatch.setattr(vanity_runner, "VANITY_TXT_DIR", tmp_path)
+
+    count = vanity_runner.run_vanity_generator(seed_start=0, patterns=["1abc"])
+    assert count == 1
+
+    files = list(Path(tmp_path).glob("vanity_*.txt"))
+    assert len(files) == 1
+    assert "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa" in files[0].read_text()


### PR DESCRIPTION
## Summary
- Avoid AttributeError when logging vanity output directory by wrapping `ensure_dir` result with `Path`
- Add test to ensure vanity generator writes files correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4363a462c83279f52156aad01b608