### PR TITLE
Add robust vanity file parsing and rotation failsafe

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -259,6 +259,7 @@ MAX_OUTPUT_LINES = VANITY_ROTATE_LINES  # legacy alias
 MAX_OUTPUT_FILE_SIZE = VANITY_MAX_BYTES  # legacy alias
 USE_GPU = True
 ROTATE_INTERVAL_SECONDS = 60
+ROTATE_MAX_WAIT_SECONDS = int(os.getenv("ROTATE_MAX_WAIT_SECONDS", "600"))
 VANITY_MODE = "both"  # 'both' -> -b, 'uncompressed' -> -u, 'compressed' -> (no flag)
 
 # ===================== ✅ ENABLED FEATURES ==========================

--- a/core/keygen.py
+++ b/core/keygen.py
@@ -6,6 +6,7 @@ import subprocess
 import threading
 import secrets
 import platform
+import re
 from datetime import datetime
 from collections import deque
 
@@ -17,6 +18,7 @@ from config.settings import (
     MAX_OUTPUT_LINES,
     ROTATE_INTERVAL_SECONDS,
     FILES_PER_BATCH,
+    ROTATE_MAX_WAIT_SECONDS,
 )
 from config.constants import SECP256K1_ORDER
 from core.checkpoint import (
@@ -174,6 +176,51 @@ def generate_random_seed(min_bits=128):
 
 
 # ---------------------------------------------------------------------------
+# VanitySearch output parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_vanity_file(path):
+    """Return number of keys and first/last seed from a VanitySearch file.
+
+    Supports both ``Priv (HEX):`` (VanitySearch) and ``Privkey:`` (oclvanity*)
+    line formats. Falls back to a regex search and skips malformed lines.
+    """
+
+    lines = 0
+    first_seed = None
+    last_seed = None
+    pattern = re.compile(r"(?i)priv(?:key)?(?: \(hex\))?:\s*(?:0x)?([0-9a-f]+)")
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+            for raw in fh:
+                line = raw.strip()
+                hex_part = None
+                if line.startswith("Priv (HEX):") or line.startswith("Privkey:"):
+                    hex_part = line.split(":", 1)[1].strip()
+                else:
+                    m = pattern.search(line)
+                    if m:
+                        hex_part = m.group(1)
+                if not hex_part:
+                    continue
+                hex_part = hex_part.replace("0x", "")
+                try:
+                    seed_int = int(hex_part, 16)
+                except ValueError:
+                    continue
+                if first_seed is None:
+                    first_seed = seed_int
+                last_seed = seed_int
+                lines += 1
+    except FileNotFoundError:
+        return 0, None, None
+
+    return lines, first_seed, last_seed
+
+
+# ---------------------------------------------------------------------------
 # VanitySearch runner (single-file run + rotation)
 # ---------------------------------------------------------------------------
 
@@ -281,30 +328,45 @@ def run_vanitysearch_stream(
             - rotate by lines (MAX_OUTPUT_LINES)
             """
             start = time.time()
+            last_size = -1
+            saw_growth = False
             while p.poll() is None:
                 if pause_event and pause_event.is_set():
                     logger.info(
-                        "⏸️ Pause requested. Terminating VanitySearch process..."
+                        "⏸️ Pause requested. Terminating VanitySearch process...",
                     )
                     p.terminate()
                     break
-                if time.time() - start >= ROTATE_INTERVAL_SECONDS:
+                now = time.time()
+                if saw_growth and now - start >= ROTATE_INTERVAL_SECONDS:
                     logger.info(
-                        "⏱️ Rotation interval reached. Terminating process to rotate file."
+                        "⏱️ Rotation interval reached. Terminating process to rotate file.",
+                    )
+                    p.terminate()
+                    break
+                if (not saw_growth) and now - start >= ROTATE_MAX_WAIT_SECONDS:
+                    logger.warning(
+                        "⚠️ No output detected; terminating to avoid hang after %s seconds",
+                        ROTATE_MAX_WAIT_SECONDS,
                     )
                     p.terminate()
                     break
                 try:
                     if os.path.exists(path):
-                        # Size-based rotation
-                        if os.path.getsize(path) >= MAX_OUTPUT_FILE_SIZE:
+                        size = os.path.getsize(path)
+                        if size != last_size:
+                            if size > 0 and size > last_size:
+                                if not saw_growth:
+                                    saw_growth = True
+                                    start = now
+                            last_size = size
+                        if size >= MAX_OUTPUT_FILE_SIZE:
                             logger.info(
                                 f"📏 Max file size reached ({MAX_OUTPUT_FILE_SIZE} bytes). "
                                 f"Rotating file {os.path.basename(path)}"
                             )
                             p.terminate()
                             break
-                        # Line-count rotation
                         with open(path, "r", encoding="utf-8", errors="ignore") as f:
                             if sum(1 for _ in f) >= MAX_OUTPUT_LINES:
                                 logger.info(
@@ -327,31 +389,16 @@ def run_vanitysearch_stream(
         logger.exception(f"Failed to execute VanitySearch: {e}")
         return False
 
-    # Post-process output file: delete only if truly empty; update metrics
+    # Post-process output file: use parser; do not delete zero-byte files
     if os.path.exists(current_output_path):
         size = os.path.getsize(current_output_path)
         if size == 0:
             logger.warning(f"⚠️ Output file empty: {current_output_path}")
-            os.remove(current_output_path)
             return False
 
         try:
-            with open(current_output_path, "r", encoding="utf-8") as f:
-                logger.info(f"Opened {current_output_path} for reading")
-                lines = 0
-                first_seed = None
-                last_seed = None
-                for line in f:
-                    # Keep existing marker; widen here if needed to also accept "Privkey:"
-                    if line.startswith("Priv (HEX):"):
-                        hex_val = line.split(":", 1)[1].strip().replace("0x", "")
-                        seed_int = int(hex_val, 16)
-                        if first_seed is None:
-                            first_seed = seed_int
-                        last_seed = seed_int
-                        lines += 1
+            lines, first_seed, last_seed = parse_vanity_file(current_output_path)
 
-            # Update counters/metrics and seed ranges
             from core.dashboard import update_dashboard_stat, get_metric
 
             total_keys_generated += lines
@@ -368,7 +415,7 @@ def run_vanitysearch_stream(
 
             logger.info(f"📄 File complete: {lines} lines → {current_output_path}")
         except Exception as e:
-            logger.warning(f"⚠️ Failed to count lines in {current_output_path}: {e}")
+            logger.warning(f"⚠️ Failed to parse {current_output_path}: {e}")
         return True
 
     logger.error(f"❌ Output file not created: {current_output_path}")
@@ -376,12 +423,12 @@ def run_vanitysearch_stream(
 
 
 # Dashboard metric helpers (imported here to keep module import order)
-from core.dashboard import (
+from core.dashboard import (  # noqa: E402
     init_shared_metrics,
     set_metric,
     increment_metric,
     get_metric,
-)  # noqa: E402
+)
 
 
 # ---------------------------------------------------------------------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 mypy
+base58

--- a/tests/test_vanity_parse_formats.py
+++ b/tests/test_vanity_parse_formats.py
@@ -1,0 +1,59 @@
+import importlib
+import types
+import sys
+
+# Stub heavy modules used by core.keygen
+sys_modules_backup = {}
+
+
+def setup_module(module):
+    sys_modules_backup["core.gpu_selector"] = sys.modules.get("core.gpu_selector")
+    sys.modules["core.gpu_selector"] = types.SimpleNamespace(
+        get_vanitysearch_gpu_ids=lambda: []
+    )
+    sys_modules_backup["core.logger"] = sys.modules.get("core.logger")
+    sys.modules["core.logger"] = types.SimpleNamespace(
+        get_logger=lambda *a, **k: types.SimpleNamespace(
+            info=lambda *a, **k: None,
+            error=lambda *a, **k: None,
+            warning=lambda *a, **k: None,
+            debug=lambda *a, **k: None,
+            exception=lambda *a, **k: None,
+        )
+    )
+    sys_modules_backup["core.dashboard"] = sys.modules.get("core.dashboard")
+    sys.modules["core.dashboard"] = types.SimpleNamespace(
+        update_dashboard_stat=lambda *a, **k: None,
+        get_metric=lambda *a, **k: 0,
+        init_shared_metrics=lambda *a, **k: None,
+        set_metric=lambda *a, **k: None,
+        increment_metric=lambda *a, **k: None,
+    )
+
+
+def teardown_module(module):
+    for name, mod in sys_modules_backup.items():
+        if mod is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = mod
+
+
+def test_parse_vanity_file_formats(tmp_path):
+    keygen = importlib.reload(importlib.import_module("core.keygen"))
+    sample = "\n".join(
+        [
+            "Priv (HEX): 0x10",
+            "Privkey: 20",
+            "Addr: 1abc",
+            "foo Privkey: 0x30",
+            "Priv (HEX): 40",
+            "Privkey: nothex",
+        ]
+    )
+    path = tmp_path / "vanity.txt"
+    path.write_text(sample)
+    lines, first_seed, last_seed = keygen.parse_vanity_file(path)
+    assert lines == 4
+    assert first_seed == 0x10
+    assert last_seed == 0x40


### PR DESCRIPTION
## Summary
- support both `Priv (HEX):` and `Privkey:` entries via new `parse_vanity_file`
- make VanitySearch monitoring resilient to stalled outputs with size tracking and max-wait cutoff
- avoid removing zero-byte vanity files and add test coverage for mixed formats

## Testing
- `ruff check --fix config/settings.py core/keygen.py tests/test_vanity_parse_formats.py`
- `black config/settings.py core/keygen.py tests/test_vanity_parse_formats.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c67947607083279eaba924d2b3873d