### PR TITLE
Improve dashboard metrics smoothing and mode awareness

### DIFF
--- a/dashboard/metrics_window.py
+++ b/dashboard/metrics_window.py
@@ -1,0 +1,144 @@
+"""Helpers for smoothing and displaying dashboard metrics.
+
+This module implements a small toolkit used by the GUI dashboard. It provides
+three main utilities:
+
+``KPSWindow``
+    Tracks a running keys-per-second rate using either a rolling window or an
+    exponential weighted moving average (EWMA) with ``alpha=0.3``.
+
+``ModeAwareMetricCache``
+    Keeps the last non-zero reading for metrics and renders those irrelevant to
+    the current operating mode as ``"N/A"`` so the GUI can grey them out.
+
+``CPUPercent``
+    Samples process CPU usage without blocking, caching the last non-zero value
+    to prevent the common flicker to ``0`` when sampling ``psutil``.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from typing import Deque, Dict, Tuple
+
+import psutil
+
+
+class KPSWindow:
+    """Compute a smoothed keys-per-second value.
+
+    The window keeps recent ``(timestamp, total_keys)`` samples. The raw rate is
+    derived from the oldest and newest sample that fall within the window. If
+    ``use_ewma`` is True an exponential weighted moving average is applied with
+    factor ``alpha`` (default 0.3). Otherwise a simple rolling-window average is
+    returned. The last non-zero value is cached so callers can avoid transient
+    ``0`` flicker when the underlying metric momentarily pauses.
+    """
+
+    def __init__(
+        self,
+        window_seconds: int = 10,
+        *,
+        use_ewma: bool = True,
+        alpha: float = 0.3,
+    ) -> None:
+        self.window_seconds = window_seconds
+        self.use_ewma = use_ewma
+        self.alpha = alpha
+        self.history: Deque[Tuple[float, float]] = deque()
+        self._ewma: float | None = None
+        self._last_non_zero = 0.0
+
+    def update(self, total_keys: float, timestamp: float | None = None) -> float:
+        ts = time.time() if timestamp is None else timestamp
+        self.history.append((ts, float(total_keys)))
+        # Discard samples outside the rolling window
+        while self.history and ts - self.history[0][0] > self.window_seconds:
+            self.history.popleft()
+
+        rate = 0.0
+        if len(self.history) >= 2:
+            t0, c0 = self.history[0]
+            t1, c1 = self.history[-1]
+            dt = t1 - t0
+            if dt > 0:
+                rate = (c1 - c0) / dt
+
+        if self.use_ewma:
+            if self._ewma is None:
+                self._ewma = rate
+            else:
+                self._ewma = self.alpha * rate + (1 - self.alpha) * self._ewma
+            rate = self._ewma
+
+        if rate > 0:
+            self._last_non_zero = rate
+        else:
+            rate = self._last_non_zero
+        return rate
+
+
+MODE_METRICS: Dict[str, set[str]] = {
+    "btc": {"compressed_kps", "uncompressed_kps", "rotations", "backlog"},
+    "mnemonic": {"mnemonic_sec", "derivations_sec", "gpu_ids", "rotations"},
+    "puzzle": {
+        "in_range_seeds_sec",
+        "range_coverage_pct",
+        "out_of_range_skipped",
+        "restarts",
+        "recoveries",
+    },
+    "altcoin_derive": {
+        "derive_kps",
+        "rows_sec",
+        "current_file",
+        "last_rotation",
+        "derive_recoveries",
+    },
+}
+
+
+class ModeAwareMetricCache:
+    """Cache metric values and render irrelevant ones as ``'N/A'``.
+
+    Each instance is initialised with the active mode. ``format`` returns the
+    incoming ``value`` unless the metric is not relevant for the mode, in which
+    case ``'N/A'`` is returned. Numeric metrics cache their last non-zero
+    reading to avoid temporary zeros during sampling gaps.
+    """
+
+    def __init__(self, mode: str) -> None:
+        self.mode = mode
+        self._cache: Dict[str, float] = {}
+
+    def format(self, metric: str, value) -> str | float:
+        if metric not in MODE_METRICS.get(self.mode, set()):
+            return "N/A"
+        if isinstance(value, (int, float)):
+            if value == 0:
+                return self._cache.get(metric, 0.0)
+            self._cache[metric] = float(value)
+        return value
+
+
+class CPUPercent:
+    """Non-blocking process CPU% sampler.
+
+    ``psutil.Process().cpu_percent`` with ``interval=None`` returns the delta
+    since the previous call. Without storing state this leads to alternating
+    zeros. This helper caches the last non-zero reading so callers always get a
+    meaningful value.
+    """
+
+    def __init__(self) -> None:
+        self._proc = psutil.Process()
+        # Prime internal measurement to avoid an initial zero
+        self._proc.cpu_percent(None)
+        self._last = 0.0
+
+    def sample(self) -> float:
+        val = self._proc.cpu_percent(None)
+        if val > 0.0:
+            self._last = val
+        return self._last

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import subprocess
 from datetime import datetime, timedelta
 from multiprocessing import Process
 import psutil
+from dashboard.metrics_window import CPUPercent
 from core.logger import get_logger
 
 # Wrap stdout once with UTF-8 encoding if not already wrapped
@@ -110,6 +111,7 @@ def metrics_updater(shared_metrics=None, shutdown_event=None):
         print(f"[error] ensure_metrics_ready failed in {__name__}: {e}", flush=True)
     last_kps = 0.0
     stop_event = shutdown_event or threading.Event()
+    cpu_sampler = CPUPercent()
 
     def update():
         nonlocal last_kps
@@ -137,7 +139,7 @@ def metrics_updater(shared_metrics=None, shutdown_event=None):
             vm = psutil.virtual_memory()
             ram_percent = vm.percent
             stats = {
-                'cpu_usage': f"{psutil.cpu_percent()}%",
+                'cpu_usage': f"{cpu_sampler.sample():.1f}%",
                 'ram_usage': f"{vm.used / (1024 ** 3):.1f} GB / {vm.total / (1024 ** 3):.1f} GB ({ram_percent}%)",
                 'disk_free_gb': round(disk_free / (1024 ** 3), 2),
                 'disk_fill_eta': disk_eta,

--- a/tests/test_metrics_window.py
+++ b/tests/test_metrics_window.py
@@ -1,0 +1,28 @@
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dashboard.metrics_window import KPSWindow, ModeAwareMetricCache
+
+
+def test_kps_window_rolling():
+    win = KPSWindow(window_seconds=5, use_ewma=False)
+    win.update(0, timestamp=0)
+    win.update(50, timestamp=5)
+    rate = win.update(100, timestamp=10)
+    assert math.isclose(rate, 10.0)
+
+
+def test_kps_window_ewma():
+    win = KPSWindow(window_seconds=10, use_ewma=True, alpha=0.3)
+    win.update(0, timestamp=0)
+    win.update(10, timestamp=1)  # raw rate 10 -> ewma 3
+    rate = win.update(30, timestamp=2)  # raw rate 15 -> ewma 6.6
+    assert math.isclose(rate, 6.6, rel_tol=1e-6)
+
+
+def test_mode_cache_irrelevant_metric():
+    cache = ModeAwareMetricCache("mnemonic")
+    assert cache.format("derive_kps", 123) == "N/A"

--- a/ui/dashboard_gui.py
+++ b/ui/dashboard_gui.py
@@ -30,7 +30,6 @@ from config.settings import (
     ALERT_CHECKBOXES,
     ALERT_CREDENTIAL_WARNINGS,
     DASHBOARD_PASSWORD_HASH,
-    SHOW_ALERTS_SUCCESSFULLY_CONFIGURED_TYPES,
     SHOW_ALERT_TYPE_SELECTOR_CHECKBOXES,
     SHOW_CONTROL_BUTTONS_MAIN,
     SHOW_DELETE_DASHBOARD_DATA_BUTTON,
@@ -798,7 +797,7 @@ def start_dashboard():
             root.destroy()
             return
         root.deiconify()
-    app = DashboardGUI(root)
+    DashboardGUI(root)
     root.mainloop()
 
 


### PR DESCRIPTION
## Summary
- add `dashboard.metrics_window` with EWMA/rolling KPS, mode-aware metric cache and CPU sampler
- integrate new CPU sampler in metrics updater to avoid zero flicker
- clean dashboard GUI imports and remove unused variable
- add unit tests for KPS window and mode-aware cache

## Testing
- `ruff check --select F401,F841 ui/dashboard_gui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c688485d648327bf2915c7e4607430