### PR TITLE
Enforce puzzle range bounds and harden seed tracker

### DIFF
--- a/core/puzzle_queue.py
+++ b/core/puzzle_queue.py
@@ -14,6 +14,13 @@ from core.paths import LOG_DIR as LOG_DIR_P
 from core.logger import get_logger
 from utils.puzzle import get_puzzle_info
 
+try:  # pragma: no cover - optional in minimal environments
+    from core.dashboard import increment_metric
+except Exception:  # pragma: no cover
+    def increment_metric(*args, **kwargs):
+        """Fallback metric increment when dashboard is unavailable."""
+        return None
+
 logger = get_logger(__name__)
 
 DB_PATH = str((Path(LOG_DIR_P) / "work_queue.db").resolve())
@@ -195,6 +202,18 @@ def next_seed(puzzle: int, assignee: str, chunk_index: Optional[int] = None) -> 
             return None  # no more work
         start, end = claim
         cur = start
+
+    start_bound, end_bound = _get_bounds(puzzle)
+    if not (start_bound <= start < end <= end_bound):
+        logger.debug(
+            "Chunk [%x, %x) outside puzzle range [%x, %x) — skipping",
+            start,
+            end,
+            start_bound,
+            end_bound,
+        )
+        increment_metric("out_of_range_skipped", 1)
+        return None
 
     seed = cur
     save_checkpoint(puzzle, {"chunk_start": start, "chunk_end": end, "cursor": seed + 1})

--- a/core/seed_tracker.py
+++ b/core/seed_tracker.py
@@ -1,81 +1,140 @@
-import json
-import os
-from bisect import bisect_left
-from typing import List, Tuple
-from pathlib import Path
+"""Track used seed ranges with a SQLite backend.
 
-from config.settings import LOG_DIR
+This module maintains a lightweight database of processed seeds.  It replaces
+the previous JSON based tracker with a more robust solution that supports
+concurrent writers and provides quick membership checks.  Seeds are stored in a
+normalized hexadecimal form along with a ``range_id`` to distinguish different
+key spaces (e.g. standard search vs. puzzle mode).
+
+Public API:
+
+``seed_in_used_range(seed, range_id="default")``
+    Return ``True`` if ``seed`` has been recorded for ``range_id``.
+
+``record_seed_range(first, last, range_id="default")``
+    Persist every seed in ``[first, last]`` for ``range_id``.
+
+``get_condensed_ranges(range_id="default")``
+    Return a list of consolidated ``(start, end)`` pairs for ``range_id``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from typing import List, Tuple
+
 from core.paths import LOG_DIR as LOG_DIR_P, ensure_dirs
 
-SEED_RANGES_PATH = str((Path(LOG_DIR_P) / "used_seeds.json").resolve())
+# SQLite database path and table definition
+SEED_DB_PATH = str((Path(LOG_DIR_P) / "used_seeds.db").resolve())
 
 
-def _load_ranges() -> List[Tuple[int, int]]:
-    """Load raw ranges from disk without modification."""
-    if not Path(SEED_RANGES_PATH).exists():
-        return []
+def _norm(seed: int | str) -> str:
+    """Return a 64-char lowercase hex representation for ``seed``."""
+    return f"{int(seed):064x}"
+
+
+def _connect() -> sqlite3.Connection:
+    """Return a SQLite connection in WAL mode."""
+    ensure_dirs()
+    conn = sqlite3.connect(SEED_DB_PATH, timeout=30, check_same_thread=False)
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS used_seeds (
+            range_id  TEXT NOT NULL,
+            seed_norm TEXT NOT NULL,
+            PRIMARY KEY (seed_norm, range_id)
+        )
+        """
+    )
+    return conn
+
+
+def _retry(op, *args, **kwargs):
+    """Execute ``op`` with retries when the database is locked."""
+    for _ in range(5):
+        try:
+            return op(*args, **kwargs)
+        except sqlite3.OperationalError as exc:  # pragma: no cover - rare
+            if "locked" in str(exc).lower():
+                time.sleep(0.1)
+                continue
+            raise
+    raise RuntimeError("database is locked")
+
+
+def seed_in_used_range(seed: int | str, range_id: str = "default") -> bool:
+    """Return ``True`` if ``seed`` was previously recorded for ``range_id``."""
+
+    conn = _connect()
     try:
-        with open(SEED_RANGES_PATH, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        ranges = []
-        for item in data:
-            start = int(item.get("start", 0))
-            end = int(item.get("end", 0))
-            ranges.append((start, end))
-        return ranges
-    except Exception:
+        def _op():
+            cur = conn.execute(
+                "SELECT 1 FROM used_seeds WHERE range_id=? AND seed_norm=? LIMIT 1",
+                (range_id, _norm(seed)),
+            )
+            return cur.fetchone() is not None
+
+        return _retry(_op)
+    finally:
+        conn.close()
+
+
+def record_seed_range(first: int | str, last: int | str, range_id: str = "default") -> None:
+    """Record every seed in ``[first, last]`` for ``range_id``.
+
+    Duplicate inserts are ignored thanks to the primary key constraint.
+    """
+
+    start, end = int(first), int(last)
+    if end < start:
+        start, end = end, start
+    seeds = [(range_id, _norm(s)) for s in range(start, end + 1)]
+
+    conn = _connect()
+    try:
+        def _op():
+            with conn:
+                conn.executemany(
+                    "INSERT OR IGNORE INTO used_seeds (range_id, seed_norm) VALUES (?, ?)",
+                    seeds,
+                )
+
+        _retry(_op)
+    finally:
+        conn.close()
+
+
+def get_condensed_ranges(range_id: str = "default") -> List[Tuple[int, int]]:
+    """Return consolidated seed ranges for ``range_id``."""
+
+    conn = _connect()
+    try:
+        def _op():
+            cur = conn.execute(
+                "SELECT seed_norm FROM used_seeds WHERE range_id=? ORDER BY seed_norm",
+                (range_id,),
+            )
+            return [int(r[0], 16) for r in cur.fetchall()]
+
+        seeds = _retry(_op)
+    finally:
+        conn.close()
+
+    if not seeds:
         return []
 
+    ranges: List[Tuple[int, int]] = []
+    start = prev = seeds[0]
+    for s in seeds[1:]:
+        if s == prev + 1:
+            prev = s
+            continue
+        ranges.append((start, prev))
+        start = prev = s
+    ranges.append((start, prev))
+    return ranges
 
-def _save_ranges(ranges: List[Tuple[int, int]]) -> None:
-    Path(SEED_RANGES_PATH).parent.mkdir(parents=True, exist_ok=True)
-    data = [{"start": s, "end": e} for s, e in ranges]
-    with open(SEED_RANGES_PATH, "w", encoding="utf-8") as f:
-        json.dump(data, f)
-
-
-def _condense_ranges(ranges: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
-    """Return sorted, non-overlapping ranges merged where necessary."""
-    if not ranges:
-        return []
-    ranges = sorted((int(s), int(e)) for s, e in ranges)
-    merged = [ranges[0]]
-    for cur_start, cur_end in ranges[1:]:
-        prev_start, prev_end = merged[-1]
-        if cur_start <= prev_end + 1:
-            merged[-1] = (prev_start, max(prev_end, cur_end))
-        else:
-            merged.append((cur_start, cur_end))
-    return merged
-
-
-def condense_seed_log() -> None:
-    """Load, merge and persist the used seed ranges to keep them minimal."""
-    ranges = _condense_ranges(_load_ranges())
-    _save_ranges(ranges)
-
-
-def get_condensed_ranges() -> List[Tuple[int, int]]:
-    """Return the current used seed ranges in condensed form."""
-    return _condense_ranges(_load_ranges())
-
-
-def record_seed_range(start: int, end: int) -> None:
-    """Record a processed seed range, merging with existing ranges."""
-    ranges = _load_ranges()
-    ranges.append((int(start), int(end)))
-    _save_ranges(_condense_ranges(ranges))
-
-
-def seed_in_used_range(seed: int, ranges: List[Tuple[int, int]] | None = None) -> bool:
-    """Return ``True`` if ``seed`` falls within a previously used range."""
-    seed = int(seed)
-    if ranges is None:
-        ranges = _condense_ranges(_load_ranges())
-    starts = [s for s, _ in ranges]
-    idx = bisect_left(starts, seed)
-    if idx < len(ranges) and ranges[idx][0] <= seed <= ranges[idx][1]:
-        return True
-    if idx > 0 and ranges[idx - 1][0] <= seed <= ranges[idx - 1][1]:
-        return True
-    return False

--- a/tests/test_puzzle_queue.py
+++ b/tests/test_puzzle_queue.py
@@ -57,3 +57,28 @@ def test_puzzle_queue_specific_chunk(tmp_path, monkeypatch):
     assert seed1 == start_bound + 5 * pq.CHUNK_SIZE
     seed2 = pq.next_seed(76, "worker1", chunk_index=5)
     assert seed2 == seed1 + 1
+
+
+def test_puzzle_queue_skips_out_of_range(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(paths, "LOG_DIR", tmp_path)
+    pq = importlib.reload(importlib.import_module("core.puzzle_queue"))
+    pq.init_work_queue()
+
+    calls = {}
+
+    def inc(name, amount=1):
+        calls[name] = calls.get(name, 0) + amount
+
+    monkeypatch.setattr(pq, "increment_metric", inc, raising=False)
+
+    start_bound, _ = pq._get_bounds(76)
+
+    def fake_claim_next_chunk(puzzle, assignee):
+        return start_bound - 10, start_bound - 5
+
+    monkeypatch.setattr(pq, "claim_next_chunk", fake_claim_next_chunk)
+
+    seed = pq.next_seed(76, "worker1")
+    assert seed is None
+    assert calls.get("out_of_range_skipped") == 1

--- a/tests/test_seed_tracker.py
+++ b/tests/test_seed_tracker.py
@@ -1,10 +1,12 @@
-import json
+import threading
+import sqlite3
+
 from core import seed_tracker
 
 
 def test_seed_tracker_roundtrip(tmp_path, monkeypatch):
-    log_path = tmp_path / "ranges.json"
-    monkeypatch.setattr(seed_tracker, "SEED_RANGES_PATH", str(log_path))
+    db_path = tmp_path / "used_seeds.db"
+    monkeypatch.setattr(seed_tracker, "SEED_DB_PATH", str(db_path))
 
     assert seed_tracker.seed_in_used_range(10) is False
     seed_tracker.record_seed_range(5, 15)
@@ -13,9 +15,29 @@ def test_seed_tracker_roundtrip(tmp_path, monkeypatch):
 
     ranges = seed_tracker.get_condensed_ranges()
     assert ranges == [(5, 25)]
-    assert seed_tracker.seed_in_used_range(10, ranges) is True
-    assert seed_tracker.seed_in_used_range(30, ranges) is False
+    assert seed_tracker.seed_in_used_range(10) is True
+    assert seed_tracker.seed_in_used_range(30) is False
 
-    with open(log_path, "r", encoding="utf-8") as f:
-        data = json.load(f)
-    assert data == [{"start": 5, "end": 25}]
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute("SELECT COUNT(*) FROM used_seeds").fetchone()[0]
+    finally:
+        conn.close()
+    assert rows == 21  # seeds 5..25 inclusive
+
+
+def test_seed_tracker_concurrency(tmp_path, monkeypatch):
+    db_path = tmp_path / "used_seeds.db"
+    monkeypatch.setattr(seed_tracker, "SEED_DB_PATH", str(db_path))
+
+    def worker():
+        seed_tracker.record_seed_range(1, 5)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    ranges = seed_tracker.get_condensed_ranges()
+    assert ranges == [(1, 5)]


### PR DESCRIPTION
## Summary
- add debug metric instrumentation and range validation for puzzle chunks
- replace JSON seed tracker with SQLite WAL store and duplicate-safe inserts
- test seed tracker concurrency and puzzle range enforcement

## Testing
- `pytest tests/test_seed_tracker.py tests/test_puzzle_queue.py tests/test_puzzle_range_enforcement.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68c6e00b4d04832798cf607db06ac38b