### PR TITLE
Handle empty vanity outputs and document seed tracker

### DIFF
--- a/core/keygen.py
+++ b/core/keygen.py
@@ -393,7 +393,10 @@ def run_vanitysearch_stream(
         if size == 0:
             logger.warning(f"⚠️ Output file empty: {current_output_path}")
             os.remove(current_output_path)
-            return False
+            # Treat an empty file as a completed rotation so the next
+            # VanitySearch run moves on to a fresh filename instead of
+            # repeatedly reusing the same slot.
+            return True
 
         try:
             lines, first_seed, last_seed = parse_vanity_file(current_output_path)

--- a/readme.md
+++ b/readme.md
@@ -301,6 +301,36 @@ Additional options mirror the specification:
 
 ---
 
+### 🌱 Seed usage database
+
+AllInKeys keeps a rolling SQLite database of every seed range that has been
+scanned so workers never repeat each other.  The file lives at
+`logs/used_seeds.db` and is managed by `core.seed_tracker`:
+
+- `record_seed_range(first, last, range_id="default")` writes every seed in the
+  inclusive range.  The keygen loop calls this automatically once a
+  VanitySearch file is parsed so your local progress is persisted.
+- `get_condensed_ranges(range_id="default")` merges the individual seeds back
+  into contiguous spans.  `core.keygen.generate_random_seed` uses this to skip
+  previously scanned space before queuing fresh candidates.
+- `seed_in_used_range(seed, range_id="default")` returns `True` when a seed has
+  already been seen.
+
+To merge ranges produced by friends or other rigs, feed them into
+`record_seed_range` under a shared `range_id`:
+
+```python
+from core.seed_tracker import record_seed_range
+
+# Merge a partner's batch and track it separately
+record_seed_range(0x1234, 0x4321, range_id="community")
+```
+
+Any ranges stored under a given `range_id` are excluded the next time new seeds
+are queued, keeping the search pointed at fresh, never‑scanned territory.
+
+---
+
 ## 🔔 Supported Alert Channels
 
 - 🔊 Audio file alert (`.wav`, `.mp3`)

--- a/tests/test_keygen_empty_output.py
+++ b/tests/test_keygen_empty_output.py
@@ -1,0 +1,52 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+
+
+def test_empty_vanity_output_advances(monkeypatch, tmp_path):
+    """Empty VanitySearch outputs should still advance rotation."""
+
+    # Ensure the keygen module uses the temporary output directory.
+    keygen = importlib.import_module("core.keygen")
+
+    fake_exe = tmp_path / "vanitysearch"
+    fake_exe.write_text("")
+    fake_exe.chmod(0o755)
+
+    monkeypatch.setattr(keygen, "VANITYSEARCH_PATH", fake_exe)
+    monkeypatch.setattr(keygen, "VANITY_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(keygen, "ROTATE_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(keygen, "get_vanitysearch_gpu_ids", lambda: [])
+
+    class DummyProc:
+        def __init__(self, cmd, stdout=None, stderr=None, env=None):
+            self.cmd = cmd
+            self.pid = 12345
+            self._terminated = False
+            out_path = Path(cmd[cmd.index("-o") + 1])
+            out_path.touch()
+
+        def terminate(self):
+            self._terminated = True
+
+        def poll(self):
+            return 0 if self._terminated else None
+
+        def wait(self):
+            self._terminated = True
+            return 0
+
+    monkeypatch.setattr(keygen.subprocess, "Popen", DummyProc)
+
+    result = keygen.run_vanitysearch_stream(0x1, 0, 0, None, None)
+    assert result is True
+
+    output_path = Path(tmp_path) / "batch_0_part_0_seed_00000001.txt"
+    assert not output_path.exists()


### PR DESCRIPTION
## Summary
- ensure zero-length VanitySearch outputs are treated as completed rotations and add a regression test
- document how the seed usage database works and how to merge ranges from other workers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdd8fbb8488327b081849425768c4a