### PR TITLE
Ensure vanity search advances when outputs are missing

### DIFF
--- a/core/keygen.py
+++ b/core/keygen.py
@@ -292,6 +292,18 @@ def run_vanitysearch_stream(
     )
     last_output_file = current_output_path
 
+    # Ensure we start from a clean slate so previous runs do not bleed into the
+    # new VanitySearch execution. If a stale file exists we remove it first.
+    try:
+        if os.path.exists(current_output_path):
+            os.remove(current_output_path)
+    except OSError:
+        logger.warning(
+            "⚠️ Unable to remove stale VanitySearch output %s before launch",
+            current_output_path,
+            exc_info=True,
+        )
+
     # Normalize pattern and ensure it's final positional arg
     pattern = str(VANITY_PATTERN).strip()
     if (pattern.startswith('"') and pattern.endswith('"')) or (
@@ -339,6 +351,8 @@ def run_vanitysearch_stream(
         )
         logger.info(f"Spawned VanitySearch PID {proc.pid} with args {cmd_preview}")
 
+        rotation_triggered = threading.Event()
+
         def monitor_process(p, path):
             """Monitor file size/lines and pause requests while VanitySearch runs."""
 
@@ -354,6 +368,7 @@ def run_vanitysearch_stream(
                     logger.info(
                         "⏱️ Rotation interval reached. Terminating process to rotate file.",
                     )
+                    rotation_triggered.set()
                     p.terminate()
                     break
                 try:
@@ -363,6 +378,7 @@ def run_vanitysearch_stream(
                                 f"📏 Max file size reached ({MAX_OUTPUT_FILE_SIZE} bytes). "
                                 f"Rotating file {os.path.basename(path)}"
                             )
+                            rotation_triggered.set()
                             p.terminate()
                             break
                         with open(path, "r", encoding="utf-8", errors="ignore") as f:
@@ -371,6 +387,7 @@ def run_vanitysearch_stream(
                                     f"📏 Max line count reached ({MAX_OUTPUT_LINES} lines). "
                                     f"Rotating file {os.path.basename(path)}"
                                 )
+                                rotation_triggered.set()
                                 p.terminate()
                                 break
                 except FileNotFoundError:
@@ -393,7 +410,10 @@ def run_vanitysearch_stream(
         if size == 0:
             logger.warning(f"⚠️ Output file empty: {current_output_path}")
             os.remove(current_output_path)
-            return False
+            # Treat an empty file as a completed rotation so the next
+            # VanitySearch run moves on to a fresh filename instead of
+            # repeatedly reusing the same slot.
+            return True
 
         try:
             lines, first_seed, last_seed = parse_vanity_file(current_output_path)
@@ -417,7 +437,26 @@ def run_vanitysearch_stream(
             logger.warning(f"⚠️ Failed to parse {current_output_path}: {e}")
         return True
 
-    logger.error(f"❌ Output file not created: {current_output_path}")
+    return_code = getattr(proc, "returncode", None)
+    if rotation_triggered.is_set():
+        logger.info(
+            "🔁 Rotation triggered before VanitySearch produced output for %s",
+            current_output_path,
+        )
+        return True
+
+    if return_code in (0, None):
+        logger.info(
+            "ℹ️ VanitySearch exited without producing %s (no hits). Advancing.",
+            current_output_path,
+        )
+        return True
+
+    logger.error(
+        "❌ Output file not created: %s (VanitySearch return code=%s)",
+        current_output_path,
+        return_code,
+    )
     return False
 
 

--- a/readme.md
+++ b/readme.md
@@ -301,6 +301,36 @@ Additional options mirror the specification:
 
 ---
 
+### 🌱 Seed usage database
+
+AllInKeys keeps a rolling SQLite database of every seed range that has been
+scanned so workers never repeat each other.  The file lives at
+`logs/used_seeds.db` and is managed by `core.seed_tracker`:
+
+- `record_seed_range(first, last, range_id="default")` writes every seed in the
+  inclusive range.  The keygen loop calls this automatically once a
+  VanitySearch file is parsed so your local progress is persisted.
+- `get_condensed_ranges(range_id="default")` merges the individual seeds back
+  into contiguous spans.  `core.keygen.generate_random_seed` uses this to skip
+  previously scanned space before queuing fresh candidates.
+- `seed_in_used_range(seed, range_id="default")` returns `True` when a seed has
+  already been seen.
+
+To merge ranges produced by friends or other rigs, feed them into
+`record_seed_range` under a shared `range_id`:
+
+```python
+from core.seed_tracker import record_seed_range
+
+# Merge a partner's batch and track it separately
+record_seed_range(0x1234, 0x4321, range_id="community")
+```
+
+Any ranges stored under a given `range_id` are excluded the next time new seeds
+are queued, keeping the search pointed at fresh, never‑scanned territory.
+
+---
+
 ## 🔔 Supported Alert Channels
 
 - 🔊 Audio file alert (`.wav`, `.mp3`)

--- a/tests/test_keygen_empty_output.py
+++ b/tests/test_keygen_empty_output.py
@@ -1,0 +1,103 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+
+
+def test_empty_vanity_output_advances(monkeypatch, tmp_path):
+    """Empty VanitySearch outputs should still advance rotation."""
+
+    monkeypatch.delitem(sys.modules, "core.keygen", raising=False)
+    keygen = importlib.import_module("core.keygen")
+
+    # Ensure the keygen module uses the temporary output directory.
+    fake_exe = tmp_path / "vanitysearch"
+    fake_exe.write_text("")
+    fake_exe.chmod(0o755)
+
+    monkeypatch.setattr(keygen, "VANITYSEARCH_PATH", fake_exe)
+    monkeypatch.setattr(keygen, "VANITY_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(keygen, "ROTATE_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(keygen, "get_vanitysearch_gpu_ids", lambda: [])
+
+    class DummyProc:
+        def __init__(self, cmd, stdout=None, stderr=None, env=None):
+            self.cmd = cmd
+            self.pid = 12345
+            self._terminated = False
+            self.returncode = None
+            out_path = Path(cmd[cmd.index("-o") + 1])
+            out_path.touch()
+
+        def terminate(self):
+            self._terminated = True
+            if self.returncode is None:
+                self.returncode = -15
+
+        def poll(self):
+            if self._terminated and self.returncode is None:
+                return 0
+            return self.returncode if self._terminated else None
+
+        def wait(self):
+            self._terminated = True
+            self.returncode = 0
+            return 0
+
+    monkeypatch.setattr(keygen.subprocess, "Popen", DummyProc)
+
+    result = keygen.run_vanitysearch_stream(0x1, 0, 0, None, None)
+    assert result is True
+
+    output_path = Path(tmp_path) / "batch_0_part_0_seed_00000001.txt"
+    assert not output_path.exists()
+
+
+def test_missing_vanity_output_advances(monkeypatch, tmp_path):
+    """Missing VanitySearch outputs should still advance rotation."""
+
+    monkeypatch.delitem(sys.modules, "core.keygen", raising=False)
+    keygen = importlib.import_module("core.keygen")
+
+    fake_exe = tmp_path / "vanitysearch"
+    fake_exe.write_text("")
+    fake_exe.chmod(0o755)
+
+    monkeypatch.setattr(keygen, "VANITYSEARCH_PATH", fake_exe)
+    monkeypatch.setattr(keygen, "VANITY_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(keygen, "ROTATE_INTERVAL_SECONDS", 5)
+    monkeypatch.setattr(keygen, "get_vanitysearch_gpu_ids", lambda: [])
+
+    class DummyProcNoFile:
+        def __init__(self, cmd, stdout=None, stderr=None, env=None):
+            self.cmd = cmd
+            self.pid = 67890
+            self.returncode = None
+            self._done = False
+
+        def terminate(self):
+            self._done = True
+            if self.returncode is None:
+                self.returncode = -15
+
+        def poll(self):
+            return self.returncode if self._done else None
+
+        def wait(self):
+            self._done = True
+            self.returncode = 0
+            return 0
+
+    monkeypatch.setattr(keygen.subprocess, "Popen", DummyProcNoFile)
+
+    result = keygen.run_vanitysearch_stream(0x2, 1, 0, None, None)
+    assert result is True
+
+    output_path = Path(tmp_path) / "batch_1_part_0_seed_00000002.txt"
+    assert not output_path.exists()


### PR DESCRIPTION
## Summary
- clean up stale VanitySearch targets before each run and track forced rotations so missing files still advance to the next slot
- treat successful but empty VanitySearch exits as completed rotations and cover both empty and missing-file scenarios with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdd8fbb8488327b081849425768c4a