### PR TITLE
Fix telemetry flush handling and enforce vanity rotation timeout

### DIFF
--- a/core/keygen.py
+++ b/core/keygen.py
@@ -514,8 +514,24 @@ def run_vanitysearch_stream(
             target=monitor_process, args=(proc, temp_output_path)
         )
         timer_thread.start()
-        proc.wait()
-        timer_thread.join()
+        wait_timeout = (
+            ROTATE_MAX_WAIT_SECONDS
+            if ROTATE_MAX_WAIT_SECONDS and ROTATE_MAX_WAIT_SECONDS > 0
+            else None
+        )
+        try:
+            proc.wait(timeout=wait_timeout)
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "⚠️ VanitySearch did not exit within %ss after terminate; killing.",
+                ROTATE_MAX_WAIT_SECONDS,
+            )
+            try:
+                proc.kill()
+            finally:
+                proc.wait()
+        finally:
+            timer_thread.join()
     except Exception as e:
         logger.exception(f"Failed to execute VanitySearch: {e}")
         return False

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -155,8 +155,13 @@ class TelemetryClient:
         )
         return cur.fetchall()
 
-    def _send_batch(self, batch: Iterable[Dict[str, Any]]) -> None:
-        requests.post(self.endpoint, json=list(batch), timeout=10)
+    def _send_batch(self, batch: Iterable[Dict[str, Any]]) -> requests.Response:
+        response = requests.post(self.endpoint, json=list(batch), timeout=10)
+        # Treat HTTP errors as failures so queued events are retried instead of
+        # being dropped silently. ``raise_for_status`` preserves the response on
+        # the exception for logging/backoff handling.
+        response.raise_for_status()
+        return response
 
     def flush_once(self) -> bool:
         """Flush a single batch from the queue.
@@ -177,12 +182,14 @@ class TelemetryClient:
             ids, payloads = zip(*batch)
             try:
                 logger.info(f"[Telemetry] Flushing {len(ids)} event(s) to {self.endpoint}")
-                self._send_batch([json.loads(p) for p in payloads])
-            except Exception:
+                response = self._send_batch([json.loads(p) for p in payloads])
+            except Exception as exc:
                 self._backoff = min(self._backoff * 2, self.max_backoff)
                 try:
                     logger.warning(
-                        f"[Telemetry] Flush failed; backing off to {self._backoff}s"
+                        "[Telemetry] Flush failed; backing off to %ss | reason=%s",
+                        self._backoff,
+                        getattr(getattr(exc, "response", None), "status_code", exc),
                     )
                 except Exception:
                     pass
@@ -194,7 +201,10 @@ class TelemetryClient:
                 )
             self._backoff = self.flush_seconds
             try:
-                logger.info(f"[Telemetry] Flush succeeded | sent={len(ids)}")
+                status = getattr(response, "status_code", "?")
+                logger.info(
+                    f"[Telemetry] Flush succeeded | sent={len(ids)} | status={status}"
+                )
             except Exception:
                 pass
             return True

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -2,6 +2,10 @@ import importlib
 import sqlite3
 import sys
 
+import types
+
+import requests
+
 sys.modules.pop("core.telemetry", None)
 TelemetryClient = importlib.import_module("core.telemetry").TelemetryClient
 
@@ -15,7 +19,11 @@ def test_batch_and_backoff(tmp_path, monkeypatch):
         if fail["first"]:
             fail["first"] = False
             raise Exception("offline")
-        return type("R", (), {"status_code": 200})()
+
+        def _raise_ok():
+            return None
+
+        return types.SimpleNamespace(status_code=200, raise_for_status=_raise_ok)
 
     monkeypatch.setattr("core.telemetry.requests.post", fake_post)
 
@@ -79,3 +87,47 @@ def test_disabled_mode(tmp_path, monkeypatch):
 
     assert calls == []
     assert not db_path.exists()
+
+
+def test_flush_retries_on_http_error(tmp_path, monkeypatch):
+    # Force HTTP 503 so the batch stays queued.
+    def fake_error(url, json, timeout):
+        def _raise_err():
+            raise requests.HTTPError("503", response=types.SimpleNamespace(status_code=503))
+
+        return types.SimpleNamespace(status_code=503, raise_for_status=_raise_err)
+
+    monkeypatch.setattr("core.telemetry.requests.post", fake_error)
+
+    db_path = tmp_path / "queue.db"
+    client = TelemetryClient(
+        endpoint="http://example",
+        batch_size=10,
+        flush_seconds=1,
+        max_backoff=4,
+        db_path=db_path,
+        instance_id_path=tmp_path / "id.txt",
+    )
+    client.record_event(
+        b"seed", mode="mnemonic", range_id=None, used=False, match_found=False
+    )
+
+    assert client.flush_once() is False
+    assert client._backoff == 2
+
+    conn = sqlite3.connect(db_path)
+    remaining = conn.execute("SELECT COUNT(*) FROM telemetry").fetchone()[0]
+    conn.close()
+    assert remaining == 1
+
+    # Next flush succeeds so the entry is removed.
+    def fake_ok(url, json, timeout):
+        return types.SimpleNamespace(status_code=200, raise_for_status=lambda: None)
+
+    monkeypatch.setattr("core.telemetry.requests.post", fake_ok)
+    assert client.flush_once() is True
+
+    conn = sqlite3.connect(db_path)
+    remaining = conn.execute("SELECT COUNT(*) FROM telemetry").fetchone()[0]
+    conn.close()
+    assert remaining == 0


### PR DESCRIPTION
## Summary
- ensure VanitySearch processes are killed if they ignore terminate after the rotation timeout so batches keep rolling
- treat non-success HTTP responses from the telemetry endpoint as failures, retaining events in the SQLite queue and logging the status
- expand telemetry tests to cover HTTP error retries

## Testing
- PYTHONPATH=. pytest tests/test_telemetry.py tests/test_vanity_io.py -q


------
https://chatgpt.com/codex/tasks/task_e_68d39a02811483278b83948e09dc24b0