### PR TITLE
Add configurable vanity rotation interval

### DIFF
--- a/config/SETTINGS.md
+++ b/config/SETTINGS.md
@@ -48,6 +48,7 @@ so it matches the naming convention expected by the application.
 - **Line 240 – MAX_KEYS_PER_FILE**: `100_000` – Deprecated
 - **Line 242 – VANITY_ROTATE_LINES**: `200_000`
 - **Line 243 – VANITY_MAX_BYTES**: `500 * 1024 * 1024`
+- **Line 244 – VANITY_ROTATE_SECONDS**: `60` – time-based rotation for streaming outputs (set 0/None to disable)
 - **Line 244 – MAX_OUTPUT_LINES**: `VANITY_ROTATE_LINES` – legacy alias
 - **Line 245 – MAX_OUTPUT_FILE_SIZE**: `VANITY_MAX_BYTES` – legacy alias
 - **Line 246 – USE_GPU**: `True`

--- a/config/settings.py
+++ b/config/settings.py
@@ -50,21 +50,22 @@ TELEMETRY_SERVICE_PORT = int(os.getenv("TELEMETRY_SERVICE_PORT", "8000"))
 
 
 def env_path(var: str, default: Path | str) -> Path:
-    """Return a :class:`~pathlib.Path` from ``var`` or ``default``.
-
-    Parameters
-    ----------
-    var:
-        Name of the environment variable to read.
-    default:
-        Fallback path used when the environment variable is not set.
-
-    The returned value is always converted to :class:`~pathlib.Path` and no
-    filesystem interaction (such as directory creation) is performed here.
-    """
+    """Return a :class:`~pathlib.Path` from ``var`` or ``default``."""
 
     value = os.getenv(var)
     return Path(value) if value else Path(default)
+
+
+def env_int(var: str, default: int | None) -> int | None:
+    """Return integer from environment variable, falling back to ``default``."""
+
+    raw = os.getenv(var)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
 
 
 # --------------------- API KEY ROTATION ---------------------
@@ -285,6 +286,10 @@ MAX_KEYS_PER_FILE = 100_000  # Deprecated
 # Output file rotation config (for VanitySearch stream)
 VANITY_ROTATE_LINES = 200_000
 VANITY_MAX_BYTES = 500 * 1024 * 1024
+_vanity_rotate_seconds = env_int("ALLINKEYS_VANITY_ROTATE_SECONDS", 60)
+VANITY_ROTATE_SECONDS = (
+    _vanity_rotate_seconds if _vanity_rotate_seconds and _vanity_rotate_seconds > 0 else None
+)
 MAX_OUTPUT_LINES = VANITY_ROTATE_LINES  # legacy alias
 MAX_OUTPUT_FILE_SIZE = VANITY_MAX_BYTES  # legacy alias
 USE_GPU = True

--- a/core/vanity_runner.py
+++ b/core/vanity_runner.py
@@ -23,6 +23,7 @@ from config.settings import (
     VANITY_OUTPUT_DIR,
     VANITY_ROTATE_LINES,
     VANITY_MAX_BYTES,
+    VANITY_ROTATE_SECONDS,
     ENABLE_BC1_DEFAULT,
     VANITY_MODE,
     OCLVANITYGEN_PATH,
@@ -463,6 +464,7 @@ def run_vanity_generator(seed_start: int, patterns: List[str], stop_event=None) 
                     rotate_lines=VANITY_ROTATE_LINES,
                     max_bytes=VANITY_MAX_BYTES,
                     prefix="vanity",
+                    rotate_seconds=VANITY_ROTATE_SECONDS,
                 )
                 total_lines = 0
                 try:

--- a/tests/test_vanity_runner.py
+++ b/tests/test_vanity_runner.py
@@ -40,3 +40,40 @@ def test_run_vanity_generator_creates_output(tmp_path, monkeypatch):
     files = list(Path(tmp_path).glob("vanity_*.txt"))
     assert len(files) == 1
     assert "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa" in files[0].read_text()
+
+
+def test_run_vanity_generator_uses_time_rotation(tmp_path, monkeypatch):
+    """Ensure the vanity writer receives the configured time-based rotation."""
+
+    monkeypatch.setattr(vanity_runner, "_resolve_exe", lambda: "vanity_mock")
+    monkeypatch.setattr(vanity_runner, "VANITY_OUTPUT_DIR", tmp_path)
+    monkeypatch.setattr(vanity_runner, "VANITY_ROTATE_SECONDS", 42)
+
+    observed = {}
+
+    class DummyWriter:
+        def __init__(
+            self, directory, rotate_lines, max_bytes, prefix, rotate_seconds=None
+        ):
+            observed["rotate_seconds"] = rotate_seconds
+            self.final_path = str(Path(directory) / "vanity_dummy.txt")
+
+        def write_line(self, line):
+            pass
+
+        def close(self):
+            pass
+
+        def abort(self):
+            pass
+
+    monkeypatch.setattr(vanity_runner, "RollingAtomicWriter", DummyWriter)
+    monkeypatch.setattr(
+        vanity_runner,
+        "_popen_stream",
+        lambda args: DummyProc(["1BoatSLRHtKNngkdXEeobR76b53LETtpyT"]),
+    )
+
+    count = vanity_runner.run_vanity_generator(seed_start=0, patterns=["1abc"])
+    assert count == 1
+    assert observed["rotate_seconds"] == 42


### PR DESCRIPTION
## Summary
- add an integer environment helper and expose `VANITY_ROTATE_SECONDS` for VanitySearch streams
- pass the configured interval to the rolling writer so VanitySearch rotates files by time as well as size/line count
- document the new setting and cover it with a unit test for the vanity runner

## Testing
- PYTHONPATH=. pytest tests/test_vanity_io.py tests/test_vanity_runner.py


------
https://chatgpt.com/codex/tasks/task_e_68e34c25bf8483279352deb11eb7d3f4